### PR TITLE
No recursion 20201223

### DIFF
--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -58,7 +58,7 @@ def wrap(fn, isstatic):
             return ret
         except Exception:  # noqa: E722
             Recorder().add_event(event.ExceptionEvent(parent_id=call_event_id,
-                                                    exc_info=sys.exc_info()))
+                                                      exc_info=sys.exc_info()))
             raise
     setattr(run, '_appmap_wrapped', True)
     return run

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -4,6 +4,7 @@ from functools import partial
 import threading
 from . import utils
 
+
 class _EventIds:
     id = 1
     lock = threading.Lock()
@@ -48,7 +49,6 @@ class Event:
             for k in chain.from_iterable(getattr(cls, '__slots__', [])
                                          for cls in type(self).__mro__)
         }
-
 
 
 class CallEvent(Event):

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -34,6 +34,14 @@ class _EventIds:
             tls['thread_id'] = cls.next_thread_id()
         return tls['thread_id']
 
+    @classmethod
+    def reset(cls):
+        with cls._next_thread_id_lock:
+            cls.id = 1
+            cls._next_thread_id = 0
+            tls = utils.appmap_tls()
+            tls.pop('thread_id', None)
+
 
 class Event:
     __slots__ = ['id', 'event', 'thread_id']

--- a/appmap/_implementation/py_version_check.py
+++ b/appmap/_implementation/py_version_check.py
@@ -1,6 +1,7 @@
 import platform
 import sys
 
+
 class AppMapPyVerException(Exception):
     pass
 

--- a/appmap/test/test_configuration.py
+++ b/appmap/test/test_configuration.py
@@ -13,6 +13,7 @@ def test_is_disabled_when_unset(monkeypatch):
     monkeypatch.delenv("APPMAP", raising=False)
     assert not appmap.enabled()
 
+
 def test_is_disabled_when_false(monkeypatch):
     """Test that recording is disabled when APPMAP=false"""
     monkeypatch.setenv("APPMAP", "false")

--- a/appmap/test/test_events.py
+++ b/appmap/test/test_events.py
@@ -40,6 +40,8 @@ def test_thread_ids():
     all_tids = [tids.get() for _ in range(tids.qsize())]
     assert len(set(all_tids)) == len(all_tids)  # Should all be unique
 
+    _EventIds.reset()
+
 
 @pytest.mark.datafiles(
     os.path.join(FIXTURE_DIR, 'appmap.yml'),

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -8,6 +8,7 @@ import pytest
 
 from .helpers import FIXTURE_DIR
 
+
 @pytest.mark.datafiles(
     os.path.join(FIXTURE_DIR, 'appmap.yml'),
     os.path.join(FIXTURE_DIR, 'example_class.py'),


### PR DESCRIPTION
fix for tests randomly failing

if test_events.py is executed before other tests, it sets the _EventIds._next_thread_id and does not reset it which causes the next test case to fail as thread_id is now 6.