### PR TITLE
HTTP request and response capture in Django

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#27] Capturing HTTP requests and responses when testing Django apps.
+
 ## [0.1.0.dev7] - 2021-02-18
 ### Added
 - [#26] Capturing SQL queries when testing Django apps.

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -140,6 +140,18 @@ class SqlEvent(Event):
         }
 
 
+class HttpRequestEvent(Event):
+    __slots__ = ['http_server_request']
+
+    def __init__(self, request_method, path_info, protocol):
+        super().__init__('call')
+        self.http_server_request = {
+            'request_method': request_method,
+            'path_info': path_info,
+            'protocol': protocol
+        }
+
+
 class ReturnEvent(Event):
     __slots__ = ['parent_id', 'elapsed']
 
@@ -147,6 +159,17 @@ class ReturnEvent(Event):
         super().__init__('return')
         self.parent_id = parent_id
         self.elapsed = elapsed
+
+
+class HttpResponseEvent(ReturnEvent):
+    __slots__ = ['http_server_response']
+
+    def __init__(self, status_code, mime_type, **kwargs):
+        super().__init__(**kwargs)
+        self.http_server_response = {
+            'status_code': status_code,
+            'mime_type': mime_type
+        }
 
 
 class ExceptionEvent(ReturnEvent):

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -113,13 +113,13 @@ def pytest_runtestloop(session):
 
 
 @pytest.hookimpl(hookwrapper=True)
-def pytest_pyfunc_call(pyfuncitem):
+def pytest_runtest_call(item):
     if not env.enabled():
         yield
         return
 
-    session = pyfuncitem.session
-    item = FuncItem(pyfuncitem)
+    session = item.session
+    item = FuncItem(item)
     metadata = dict(session.appmap_metadata)
     metadata.update(item.metadata)
     logger.debug('pytest_pyfunc_call, metadata %s', repr(metadata))

--- a/appmap/test/test_django.py
+++ b/appmap/test/test_django.py
@@ -1,11 +1,14 @@
+# flake8: noqa: E402
+# pylint: disable=unused-import, redefined-outer-name
+
 import pytest
 from appmap._implementation.recording import Recorder
 
 pytest.importorskip('django')
 
-# flake8: noqa: E402
 import django.conf
 import django.db
+import django.test
 import appmap.django  # noqa: F401
 
 django.conf.settings.configure(
@@ -29,3 +32,19 @@ def test_sql_capture(events):
     conn.cursor().execute('SELECT 1').fetchall()
 
     assert events[0].sql_query['sql'] == 'SELECT 1'
+
+
+def test_http_capture(events):
+    client = django.test.Client()
+    client.get('/test')
+
+    assert events[0].http_server_request == {
+        'request_method': 'GET',
+        'path_info': '/test',
+        'protocol': 'HTTP/1.1'
+    }
+
+    assert events[1].http_server_response == {
+        'status_code': 404,
+        'mime_type': 'text/html'
+    }


### PR DESCRIPTION
The middleware injection is a bit inelegant, but it works pretty well.

#5 wasn't actually blocking this; unittest cases driven by pytest still activate some hooks, just not the one we were using. I've changed the hook to work with them.

Fixes #27.