### PR TITLE
Relax python version requirement to 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-python: 
-- "3.5"
+python:
 - "3.9"
 
 stages:
@@ -21,9 +20,27 @@ jobs:
     script:
     - poetry run pylint appmap
     - poetry run vermin -t=3.5- appmap
+    
   - stage: test
+    python: "3.5"
     script:
-    - poetry run pytest -svv
+    - poetry run tox
+  - stage: test
+    python: "3.6"
+    script:
+    - poetry run tox
+  - stage: test
+    python: "3.7"
+    script:
+    - poetry run tox
+  - stage: test
+    python: "3.8"
+    script:
+    - poetry run tox
+  - stage: test
+    python: "3.9"
+    script:
+    - poetry run tox
 
   - stage: deploy
     script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
   - stage: lint
     script:
     - poetry run pylint appmap
-    
+    - poetry run vermin -t=3.7- appmap
   - stage: test
     script:
     - poetry run pytest -svv

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
-python: "3.9"
+python: 
+- "3.5"
+- "3.9"
 
 stages:
 - lint
@@ -18,7 +20,7 @@ jobs:
   - stage: lint
     script:
     - poetry run pylint appmap
-    - poetry run vermin -t=3.7- appmap
+    - poetry run vermin -t=3.5- appmap
   - stage: test
     script:
     - poetry run pytest -svv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Use tox for testing multiple versions of Python.
+
 ### Changed
 - Relax the python version requirement to 3.5.
+
+### Fixed
+- Fix handling of builtin functions assigned as attributes of a class. They look like
+  static methods, (i.e. `isinstance(m, (staticmethod, types.BuiltinMethodType))` is
+  `True`), but they don't have a `__func__` attribute.
 
 ### ## [0.1.0.dev8] - 2021-02-22
 - [#27] Capturing HTTP requests and responses when testing Django apps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Relax the python version requirement to 3.5.
+
 ### ## [0.1.0.dev8] - 2021-02-22
 - [#27] Capturing HTTP requests and responses when testing Django apps.
 
@@ -107,7 +110,7 @@ testing. Also adds a Travis config to run them all.
 
 
 [Unreleased]: https://github.com/applandinc/appmap-python/compare/0.1.0.dev8...HEAD
-[0.1.0.dev8]: https://github.com/applandinc/appmap-python/compare/0.1.0.dev67...0.1.0.dev8
+[0.1.0.dev8]: https://github.com/applandinc/appmap-python/compare/0.1.0.dev7...0.1.0.dev8
 [0.1.0.dev7]: https://github.com/applandinc/appmap-python/compare/0.1.0.dev6...0.1.0.dev7
 [0.1.0.dev6]: https://github.com/applandinc/appmap-python/compare/0.1.0.dev4...0.1.0.dev6
 [0.1.0.dev4]: https://github.com/applandinc/appmap-python/compare/0.1.0.dev3...0.1.0.dev4

--- a/README.md
+++ b/README.md
@@ -241,12 +241,14 @@ you can generate a recording of the code
 [![Build Status](https://travis-ci.com/applandinc/appmap-python.svg?branch=master)](https://travis-ci.com/applandinc/appmap-python)
 
 ### Python version support
-As a package intended to be installed in as many environments as possible, appmap-python
-needs to avoid using features of python or the standard library that were added after the
-oldest version currently supported (see [above](#supported-version))
+As a package intended to be installed in as many environments as possible, `appmap-python`
+needs to avoid using features of Python or the standard library that were added after the
+oldest version currently supported (see [above](#supported-version)).
 
-While we use `vermin` to try to detect the use of newer features, it's easily
-fooled. When making changes, please respect the version requirement.
+The Travis build uses [vermin](https://github.com/netromdk/vermin) to help weed out the
+use of some invalid features. Additionally, tests are run using all supported versions of
+Python.
+
 
 ### Dependency management
 
@@ -276,12 +278,26 @@ should be reenabled as soon as possible.]
 
 
 ### Testing
+#### pytest
 [pytest](https://docs.pytest.org/en/stable/) for testing:
 
 ```
 % cd appmap-python
 % poetry run pytest
 ```
+
+#### tox
+Additionally, the `tox` configuration provides the ability to run the tests for all
+supported versions of Python and django:
+
+```sh
+% cd appmap-python
+% poetry run tox
+```
+
+Note that `tox` requires the correct version of Python to be installed before it can
+create a test environment. [pyenv](https://github.com/pyenv/pyenv) is an easy way to
+manage multiple versions of Python. 
 
 ### Code Coverage
 [coverage](https://coverage.readthedocs.io/) for coverage:

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The second option is to upload them to the [AppLand server](https://app.land) us
 
 ### Supported versions
 
-* Python 3.9
-* Pytest 6.2
+* Python >=3.5
+* Pytest >=6.1.2
 
 Support for new versions is added frequently, please check back regularly for updates.
 
@@ -239,6 +239,14 @@ you can generate a recording of the code
 ## Development
 
 [![Build Status](https://travis-ci.com/applandinc/appmap-python.svg?branch=master)](https://travis-ci.com/applandinc/appmap-python)
+
+### Python version support
+As a package intended to be installed in as many environments as possible, appmap-python
+needs to avoid using features of python or the standard library that were added after the
+oldest version currently supported (see [above](#supported-version))
+
+While we use `vermin` to try to detect the use of newer features, it's easily
+fooled. When making changes, please respect the version requirement.
 
 ### Dependency management
 

--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -128,7 +128,7 @@ def function_in_set(fn, which):
         return False
 
     ret = (class_in_set(class_name, which)
-           or name_in_set(f'{class_name}.{fn_name}', which))
+           or name_in_set('%s.%s' %(class_name, fn_name), which))
 
     logger.debug(('function_in_set, class_name %s'
                   ' fnname %s'
@@ -180,8 +180,8 @@ class ConfigFilter(Filter):
             if 'exclude' in package:
                 if not isinstance(package['exclude'], list):
                     raise RuntimeError('Excludes for package'
-                                       f' "{path}" must be a list')
-                excludes = [f'{path}.{e}' for e in package['exclude']]
+                                       ' "%s" must be a list' % (path))
+                excludes = ['%s.%s' % (path, e) for e in package['exclude']]
                 self._excludes.update(excludes)
         logger.info('ConfigFilter, includes %s', self._includes)
         logger.info('ConfigFilter, excludes %s', self._excludes)

--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -6,7 +6,7 @@ import logging
 import os
 import sys
 from contextlib import contextmanager
-from functools import wraps, cached_property
+from functools import wraps
 import time
 
 import yaml
@@ -49,16 +49,15 @@ class Config:
     def initialize(cls):
         cls._instance = None
 
-    @cached_property
+    @property
     def output_dir(self):
         return os.getenv("APPMAP_OUTPUT_DIR",
                          os.path.join('tmp', 'appmap'))
-
-    @cached_property
+    @property
     def name(self):
         return self._config['name']
 
-    @cached_property
+    @property
     def packages(self):
         return self._config['packages']
 

--- a/appmap/_implementation/env.py
+++ b/appmap/_implementation/env.py
@@ -30,9 +30,10 @@ def _configure_logging():
             }
         },
         'loggers': {
-            'root': {
+            'appmap': {
                 'level': log_level,
-                'handlers': ['default']
+                'handlers': ['default'],
+                'propagate': False
             }
         }
     }

--- a/appmap/_implementation/env.py
+++ b/appmap/_implementation/env.py
@@ -13,7 +13,7 @@ def _configure_logging():
 
     log_config = os.getenv("APPMAP_LOG_CONFIG")
     log_stream = os.getenv("APPMAP_LOG_STREAM", "stderr")
-    log_stream = f'ext://sys.{log_stream}'
+    log_stream = 'ext://sys.%s' % (log_stream)
     config_dict = {
         'version': 1,
         'disable_existing_loggers': False,

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -110,7 +110,7 @@ class CallEvent(Event):
                 try:
                     value = repr(slf)
                 except Exception:  # pylint: disable=broad-except
-                    value = f'<{defined_class} object at {object_id:#02x}>'
+                    value = '<%s object at %#x>' % (defined_class, object_id)
             return {
                 "class": cls,
                 "value": value,

--- a/appmap/_implementation/generation.py
+++ b/appmap/_implementation/generation.py
@@ -1,41 +1,47 @@
 """Generate an AppMap"""
-import orjson
-from dataclasses import dataclass, field
+import json
 
 from .metadata import Metadata
 from .event import Event
 
 
-class ClassMapDict(dict):
-    pass
+# ClassMapDict needs to quack a little like a dict. If it's actually a
+# subclass of dict, though, json tries to process it without calling
+# our encoder. So, just implement the methods we need.
+class ClassMapDict:
+    def __init__(self):
+        self._dict = dict()
+
+    def setdefault(self, k, default):
+        return self._dict.setdefault(k, default)
+
+    def values(self):
+        return self._dict.values()
 
 
-@dataclass
 class ClassMapEntry:
-    name: str
-    type: str
+    # pylint: disable=redefined-builtin
+    def __init__(self, name, type):
+        self.name = name
+        # `type` is a builtin, but the appmap attribute is named
+        # `type`. So, ignore this warning, unless it turns out to
+        # actually be a problem, of course.
+        self.type = type
 
-
-@dataclass
 class PackageEntry(ClassMapEntry):
-    children: ClassMapDict = field(default_factory=ClassMapDict)
-    type: str = 'package'
+    def __init__(self, name):
+        super().__init__(name, 'package')
+        self.children = ClassMapDict()
 
-
-@dataclass
 class ClassEntry(ClassMapEntry):
-    children: ClassMapDict = field(default_factory=ClassMapDict)
-    type: str = 'class'
+    def __init__(self, name):
+        super().__init__(name, 'class')
+        self.children = ClassMapDict()
 
-
-@dataclass
 class FuncEntry(ClassMapEntry):
-    location: str
-    static: bool
-
     def __init__(self, e):
         super().__init__(e.method_id, 'function')
-        self.location = f'{e.path}:{e.lineno}'
+        self.location = '%s:%s' % (e.path, e.lineno)
         self.static = e.static
 
 
@@ -54,7 +60,7 @@ def classmap(recording):
             entry = children.setdefault(class_, ClassEntry(class_))
             children = entry.children
 
-            loc = f'{e.path}:{e.lineno}'
+            loc = '%s:%s' % (e.path, e.lineno)
             children.setdefault(loc, FuncEntry(e))
         except AttributeError:
             # Event might not have a defined_class attribute;
@@ -78,20 +84,18 @@ def appmap(recording, metadata):
     }
 
 
-class AppMapEncoder:
-    @staticmethod
-    def default(o):
+class AppMapEncoder(json.JSONEncoder):
+    def default(self, o):
         if isinstance(o, Event):
             return o.to_dict()
         elif isinstance(o, ClassMapDict):
             return list(o.values())
         elif isinstance(o, ClassMapEntry):
             return vars(o)
-        raise TypeError
+
+        return json.JSONEncoder.default(self, o)
 
 
 def dump(recording, metadata=None):
     a = appmap(recording, metadata)
-    return orjson.dumps(a, default=AppMapEncoder.default,
-                        option=(orjson.OPT_PASSTHROUGH_SUBCLASS |
-                                orjson.OPT_PASSTHROUGH_DATACLASS))
+    return json.dumps(a, cls=AppMapEncoder)

--- a/appmap/_implementation/generation.py
+++ b/appmap/_implementation/generation.py
@@ -66,7 +66,7 @@ def classmap(recording):
 
 
 def appmap(recording, metadata):
-    appmap_metadata = Metadata.to_dict()
+    appmap_metadata = Metadata().to_dict()
     if metadata:
         appmap_metadata.update(metadata)
 

--- a/appmap/_implementation/metadata.py
+++ b/appmap/_implementation/metadata.py
@@ -48,13 +48,13 @@ class Metadata:
         if annotated_tag:
             result = pattern.search(git('describe'))
             if result:
-                commits_since_annotated_tag = int(result[1])
+                commits_since_annotated_tag = int(result.group(1))
 
         commits_since_tag = None
         if tag:
             result = pattern.search(git('describe --tags'))
             if result:
-                commits_since_tag = int(result[1])
+                commits_since_tag = int(result.group(1))
 
         ret = {
             'repository': repository,

--- a/appmap/_implementation/py_version_check.py
+++ b/appmap/_implementation/py_version_check.py
@@ -7,6 +7,9 @@ class AppMapPyVerException(Exception):
 
 
 def check_py_version():
-    MIN_PY_VERSION = (3, 9)
+    MIN_PY_VERSION = (3, 5)
     if sys.version_info < MIN_PY_VERSION:
-        raise AppMapPyVerException(f'Minimum Python version supported is {MIN_PY_VERSION}, found {platform.python_version()}')
+        raise AppMapPyVerException(
+            'Minimum Python version supported is %s, found %s' %
+            (MIN_PY_VERSION, platform.python_version())
+        )

--- a/appmap/_implementation/recording.py
+++ b/appmap/_implementation/recording.py
@@ -200,10 +200,16 @@ class Recorder:
                 isstatic = utils.is_staticmethod(fn)
                 isclass = utils.is_classmethod(fn)
 
+                static = False
                 if isstatic or isclass:
-                    new_fn = self.filter_chain.wrap(fn.__func__, isstatic=True)
-                else:
-                    new_fn = self.filter_chain.wrap(fn, isstatic=False)
+                    # Static methods created with staticmethod will
+                    # have a `__func__` attribute. Other static
+                    # methods (e.g. builtins assigned to an attribute
+                    # of a class) won't. So, use `__func__` if it's
+                    # available, otherwise just wrap fn.
+                    fn = getattr(fn, '__func__', fn)
+                    static = True
+                new_fn = self.filter_chain.wrap(fn, isstatic=static)
 
                 if new_fn != fn:
                     if isstatic:

--- a/appmap/_implementation/utils.py
+++ b/appmap/_implementation/utils.py
@@ -67,11 +67,10 @@ def subprocess_run(command_args, cwd=None):
     Ret = namedtuple('Ret', ['returncode', 'stdout'])
     try:
         out = subprocess.check_output(command_args,
-                                      cwd=cwd, universal_newlines=True)
+                                      cwd=str(cwd), universal_newlines=True)
         return Ret(stdout=out, returncode=0)
     except subprocess.CalledProcessError as exc:
         return Ret(stdout=exc.stdout, returncode=exc.returncode)
-
 
 class git:
     def __init__(self, cwd=None):

--- a/appmap/_implementation/utils.py
+++ b/appmap/_implementation/utils.py
@@ -1,8 +1,10 @@
 import threading
 import types
 from collections.abc import MutableMapping
+from collections import namedtuple
+import shlex
 import subprocess
-
+import os
 
 class ThreadLocalDict(threading.local, MutableMapping):
     def __init__(self):
@@ -41,7 +43,7 @@ def is_classmethod(m):
 
 
 def fqname(cls):
-    return f'{cls.__module__}.{cls.__qualname__}'
+    return '%s.%s' % (cls.__module__, cls.__qualname__)
 
 
 def split_function_name(fn):
@@ -52,12 +54,35 @@ def split_function_name(fn):
     qualname = fn.__qualname__
     if '.' in qualname:
         class_name, fn_name = qualname.rsplit('.', 1)
-        class_name = f'{fn.__module__}.{class_name}'
+        class_name = '%s.%s' % (fn.__module__, class_name)
     else:
         class_name = fn.__module__
         fn_name = qualname
     return (class_name, fn_name)
 
 
-def subprocess_run(command_args):
-    return subprocess.run(command_args, capture_output=True, text=True, check=False)
+def subprocess_run(command_args, cwd=None):
+    if not cwd:
+        cwd = os.getcwd()
+    Ret = namedtuple('Ret', ['returncode', 'stdout'])
+    try:
+        out = subprocess.check_output(command_args,
+                                      cwd=cwd, universal_newlines=True)
+        return Ret(stdout=out, returncode=0)
+    except subprocess.CalledProcessError as exc:
+        return Ret(stdout=exc.stdout, returncode=exc.returncode)
+
+
+class git:
+    def __init__(self, cwd=None):
+        self._cwd = cwd if cwd else os.getcwd()
+
+    def __call__(self, cmd):
+        return subprocess_run(
+            shlex.split('git ' + cmd),
+            cwd=self._cwd
+        ).stdout.strip()
+
+    @property
+    def cwd(self):
+        return self._cwd

--- a/appmap/django.py
+++ b/appmap/django.py
@@ -30,7 +30,7 @@ class ExecuteWrapper:
                         times = len(params)
                     except TypeError:
                         times = '?'
-                    sql = f'{times} times {sql}'
+                    sql = '%s times %s' % (times, sql)
                 else:
                     db = context['connection']
                     cursor = context['cursor']

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -128,7 +128,7 @@ def pytest_runtest_call(item):
     path = os.path.join(session.appmap_path, fname)
 
     def write_recording(r):
-        with open(path, 'wb') as appmap_file:
+        with open(path, 'w') as appmap_file:
             appmap_file.write(generation.dump(r, metadata))
         logger.info('wrote recording %s', path)
 

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 import logging
 import pytest
 import os
@@ -42,9 +41,10 @@ class FuncItem:
 
     @property
     def feature_group(self):
-        return inflection.humanize(
-            inflection.titleize(self.class_name.removeprefix('Test'))
-        )
+        test_name = self.class_name
+        if test_name.startswith('Test'):
+            test_name = test_name[4:]
+        return inflection.humanize(inflection.titleize(test_name))
 
     @property
     def feature(self):
@@ -68,7 +68,9 @@ class FuncItem:
         if self.item.cls:
             fname = f'{self.defined_class}_{fname}'
         fname = re.sub('[^a-zA-Z0-9-_]', '_', fname)
-        return fname.removesuffix('_')
+        if fname.endswith('_'):
+            fname = fname[:-1]
+        return fname
 
     @property
     def metadata(self):
@@ -92,7 +94,6 @@ def pytest_runtestloop(session):
         yield
         return
 
-    pytest_version = importlib.metadata.version('pytest')
     session.appmap_path = os.path.join(
         configuration.Config().output_dir, 'pytest'
     )
@@ -102,7 +103,7 @@ def pytest_runtestloop(session):
         'app': configuration.Config().name,
         'frameworks': [{
             'name': 'pytest',
-            'version': pytest_version
+            'version': pytest.__version__
 
         }],
         'recorder': {

--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -52,7 +52,7 @@ class FuncItem:
 
     @property
     def scenario_name(self):
-        name = f'{self.feature[0].lower()}{self.feature[1:]}'
+        name = '%s%s' %(self.feature[0].lower(), self.feature[1:])
         if self.has_feature_group():
             name = ' '.join([self.feature_group, name])
         return name
@@ -66,7 +66,7 @@ class FuncItem:
     def filename(self):
         fname = self.item.name
         if self.item.cls:
-            fname = f'{self.defined_class}_{fname}'
+            fname = '%s_%s' % (self.defined_class, fname)
         fname = re.sub('[^a-zA-Z0-9-_]', '_', fname)
         if fname.endswith('_'):
             fname = fname[:-1]

--- a/appmap/test/appmap_test_base.py
+++ b/appmap/test/appmap_test_base.py
@@ -1,3 +1,4 @@
+from operator import itemgetter
 import os
 import platform
 import re
@@ -14,19 +15,24 @@ class AppMapTestBase:
 
     @staticmethod
     def normalize_git(git):
-        git.pop('repository') # = 'git@github.com:applandinc/appmap-python.git'
-        git.pop('branch') # = 'master'
-        git.pop('commit') # = 'xyz'
+        git.pop('repository')
+        git.pop('branch')
+        git.pop('commit')
         status = git.pop('status')
         assert isinstance(status, list)
-        git.pop('git_last_tag') # = ''
-        commits_since_last_tag = git.pop('git_commits_since_last_tag')
-        assert isinstance(commits_since_last_tag, int)
-        git.pop('git_last_annotated_tag') # = None
-        commits_since_last_annotated_tag = git.pop(
-            'git_commits_since_last_annotated_tag'
+        tag = git.pop('tag', None)
+        if tag:
+            assert isinstance(tag, str)
+        commits_since_tag = git.pop('commits_since_tag', None)
+        if commits_since_tag:
+            assert isinstance(commits_since_tag, int)
+        git.pop('annotated_tag', None)
+
+        commits_since_annotated_tag = git.pop(
+            'commits_since_annotated_tag', None
         )
-        assert isinstance(commits_since_last_annotated_tag, int)
+        if commits_since_annotated_tag:
+            assert isinstance(commits_since_annotated_tag, int)
 
     @staticmethod
     def normalize_metadata(metadata):
@@ -52,6 +58,8 @@ class AppMapTestBase:
         """
 
         def normalize(dct):
+            if 'children' in dct:
+                dct['children'].sort(key=itemgetter('name'))
             if 'elapsed' in dct:
                 elapsed = dct.pop('elapsed')
                 assert isinstance(elapsed, float)

--- a/appmap/test/appmap_test_base.py
+++ b/appmap/test/appmap_test_base.py
@@ -1,9 +1,9 @@
-import importlib
 import os
 import platform
 import re
 
 import json
+import pytest
 
 import appmap._implementation
 
@@ -40,7 +40,7 @@ class AppMapTestBase:
             for f in frameworks:
                 if f['name'] == 'pytest':
                     v = f.pop('version')
-                    assert v == importlib.metadata.version('pytest')
+                    assert v == pytest.__version__
 
     def normalize_appmap(self, generated_appmap):
         """

--- a/appmap/test/conftest.py
+++ b/appmap/test/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+from appmap._implementation import utils
+
+@pytest.fixture
+def tmp_git(tmp_path):
+    g = utils.git(cwd=tmp_path)
+    g('init')
+    utils.subprocess_run(['touch', 'README.md'], cwd=tmp_path)
+    g('add README.md')
+    g('commit -m "initial commit"')
+    g('remote add origin https://www.example.com/repo.git')
+    utils.subprocess_run(['touch', 'new_file'], cwd=tmp_path)
+    return g

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -3,7 +3,7 @@ import time
 class ClassMethodMixin:
     @classmethod
     def class_method(cls):
-        return f'ClassMethodMixin#class_method, cls {cls}'
+        return 'ClassMethodMixin#class_method, cls %s' % (cls)
 
 
 class Super:
@@ -13,7 +13,7 @@ class Super:
 
 class ExampleClass(Super, ClassMethodMixin):
     def __repr__(self):
-        return f'ExampleClass and {self.another_method()}'
+        return 'ExampleClass and %s' % (self.another_method())
 
     @staticmethod
     def static_method():

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -1,4 +1,4 @@
-
+import time
 
 class ClassMethodMixin:
     @classmethod
@@ -24,3 +24,5 @@ class ExampleClass(Super, ClassMethodMixin):
 
     def test_exception(self):
         raise Exception('test exception')
+
+    what_time_is_it = time.gmtime

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -15,6 +15,18 @@
       "type": "package",
       "children": [
         {
+          "name": "ClassMethodMixin",
+          "type": "class",
+          "children": [
+            {
+              "name": "class_method",
+              "type": "function",
+              "location": "example_class.py:4",
+              "static": true
+            }
+          ]
+        },
+        {
           "name": "ExampleClass",
           "type": "class",
           "children": [
@@ -29,18 +41,6 @@
               "type": "function",
               "location": "example_class.py:25",
               "static": false
-            }
-          ]
-        },
-        {
-          "name": "ClassMethodMixin",
-          "type": "class",
-          "children": [
-            {
-              "name": "class_method",
-              "type": "function",
-              "location": "example_class.py:4",
-              "static": true
             }
           ]
         },

--- a/appmap/test/data/pytest/expected.appmap.json
+++ b/appmap/test/data/pytest/expected.appmap.json
@@ -95,15 +95,15 @@
           "type": "class",
           "children": [
             {
-              "name": "hello_world",
-              "type": "function",
-              "location": "simple.py:8",
-              "static": false
-            },
-            {
               "name": "hello",
               "type": "function",
               "location": "simple.py:2",
+              "static": false
+            },
+            {
+              "name": "hello_world",
+              "type": "function",
+              "location": "simple.py:8",
               "static": false
             },
             {

--- a/appmap/test/data/pytest/simple.py
+++ b/appmap/test/data/pytest/simple.py
@@ -3,7 +3,7 @@ class Simple:
         return 'Hello'
 
     def world(self):
-        return 'world'
+        return 'world!'
 
     def hello_world(self):
-        return f'{self.hello()} {self.world()}!'
+        return '%s %s' % (self.hello(), self.world())

--- a/appmap/test/test_metadata.py
+++ b/appmap/test/test_metadata.py
@@ -1,0 +1,65 @@
+# pylint: disable=protected-access
+
+"""Test Metadata"""
+from appmap._implementation.metadata import Metadata
+
+class TestMetadata:
+    def test_fixture(self, tmp_git):
+        md = Metadata(cwd=tmp_git.cwd)
+        assert md._git_available() # sanity check
+
+    def test_git_metadata(self, tmp_git):
+        md = Metadata(cwd=tmp_git.cwd)
+
+        git_md = md._git_metadata()
+        expected = {
+            'repository': 'https://www.example.com/repo.git',
+            'branch': 'master',
+            'status': [
+                '?? new_file'
+            ]
+        }
+        for k,v in expected.items():
+            assert git_md[k] == v
+        missing = ('tag', 'annotated_tag',
+                   'commits_since_tag', 'commit_since_annotated_tag')
+        for m in missing:
+            assert m not in git_md
+
+    def test_tag(self, tmp_git):
+        tag = 'new_tag'
+        tmp_git('tag %s' % (tag))
+        md = Metadata(cwd=tmp_git.cwd)
+        git_md = md._git_metadata()
+
+        assert git_md['tag'] == tag
+        assert 'commits_since_tag' not in git_md
+
+    def test_annotated_tag(self, tmp_git):
+        tag = 'new_annotated_tag'
+        tmp_git('tag -a "%s" -m "add annotated tag"' % (tag))
+        md = Metadata(cwd=tmp_git.cwd)
+        git_md = md._git_metadata()
+
+        assert git_md['annotated_tag'] == tag
+        assert 'commits_since_annotated_tag' not in git_md
+
+    def test_since_tag(self, tmp_git):
+        tag = 'new_tag'
+        tmp_git('tag %s' % (tag))
+        tmp_git('add new_file')
+        tmp_git('commit -m "added new file"')
+        md = Metadata(cwd=tmp_git.cwd)
+        git_md = md._git_metadata()
+
+        assert git_md['commits_since_tag'] == 1
+
+    def test_since_annotated_tag(self, tmp_git):
+        tag = 'new_tag'
+        tmp_git('tag -a "%s" -m "add annotated tag"' % (tag))
+        tmp_git('add new_file')
+        tmp_git('commit -m "added new file"')
+        md = Metadata(cwd=tmp_git.cwd)
+        git_md = md._git_metadata()
+
+        assert git_md['commits_since_annotated_tag'] == 1

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -26,7 +26,7 @@ class TestRecording(AppMapTestBase):
             ExampleClass.static_method()
             ExampleClass.class_method()
             ExampleClass().instance_method()
-            now = ExampleClass.what_time_is_it()
+            ExampleClass.what_time_is_it()
             try:
                 ExampleClass().test_exception()
             except:  # pylint: disable=bare-except  # noqa: E722

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -16,7 +16,6 @@ class TestRecording(AppMapTestBase):
         monkeypatch.setenv("APPMAP", "true")
         monkeypatch.setenv("APPMAP_CONFIG",
                            os.path.join(data_dir, 'appmap.yml'))
-        monkeypatch.setenv("APPMAP_LOG_LEVEL", "debug")
 
         import appmap
         # Reinitialize to pick up the environment variables just set
@@ -27,6 +26,7 @@ class TestRecording(AppMapTestBase):
             ExampleClass.static_method()
             ExampleClass.class_method()
             ExampleClass().instance_method()
+            now = ExampleClass.what_time_is_it()
             try:
                 ExampleClass().test_exception()
             except:  # pylint: disable=bare-except  # noqa: E722

--- a/conftest.py
+++ b/conftest.py
@@ -7,5 +7,5 @@ pytest_plugins = ['pytester']
 
 @pytest.fixture
 def data_dir(pytestconfig):
-    yield str(os.path.join(pytestconfig.rootpath,
+    yield str(os.path.join(str(pytestconfig.rootpath),
                            'appmap', 'test', 'data'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,14 @@ pyfakefs = "^4.3.2"
 pprintpp = "^0.4.0"
 coverage = "^5.3"
 pytest-mock = "^3.5.1"
-Django = "^3.1.6"
+Django = [
+  { version = "~2.2", python = "< 3.6"},
+  { version = "^3.1.6", python = "^3.6"}
+]
 vermin = "^1.1.0"
+tox = "^3.22.0"
+tox-pyenv = "^1.1.0"
+tox-travis = "^0.12"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ pprintpp = "^0.4.0"
 coverage = "^5.3"
 pytest-mock = "^3.5.1"
 Django = "^3.1.6"
+vermin = "^1.1.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ readme = "README.md"
 authors = ["Alan Potter <alan@app.land>"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-PyYAML = "^5.3.1"
-inflection = "^0.5.1"
+python = "^3.5"
+PyYAML = "~5.3.0"
+inflection = "~0.3.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ authors = ["Alan Potter <alan@app.land>"]
 [tool.poetry.dependencies]
 python = "^3.9"
 PyYAML = "^5.3.1"
-orjson = "=3.4.6"
 inflection = "^0.5.1"
 
 [tool.poetry.dev-dependencies]

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,7 @@ pytester_example_dir = appmap/test/data
 # running in a subprocess ensures that environment variables are set
 # correctly and no classes are loaded.
 addopts = --runpytest subprocess
+
+# We're stuck at pytest ~6.1.2. This warning got removed in a later
+# version.
+filterwarnings = ignore:testdir.copy_example is an experimental api that may change over time

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+skipsdist = true
+envlist = py3{5,6,7,8,9}
+
+[testenv]
+whitelist_externals = poetry
+commands =
+    poetry install -v
+    poetry run pytest {posargs}


### PR DESCRIPTION
Eliminate all uses of features added after Python version 3.5. Add `vermin` to help weed out issues, and `tox` to test against supported versions.

There are also a couple of bug fixes here. I don't love the shenanigans in 6f2a9f1. The problem has proved resistant to my efforts to debug it, though, and the current workaround seems good enough for now. It should probably be revisited sometime soon, though.