### PR TITLE
Make sure wrap_exec_module doesn't rewrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#50] Make sure we protect against rewrapping a metapath finder's exec_module function.
+
 ### ## [0.1.0.dev10] - 2021-02-24
 ### Fixed
 - Choose the output directory on startup, make sure it's an absolute path.

--- a/appmap/_implementation/recording.py
+++ b/appmap/_implementation/recording.py
@@ -218,6 +218,11 @@ class Recorder:
 
 
 def wrap_exec_module(exec_module):
+    marker = '_appmap_exec_module_'
+    if getattr(exec_module, marker, None):
+        logger.debug('%s already wrapped', exec_module)
+        return exec_module
+
     @wraps(exec_module)
     def wrapped_exec_module(*args, **kwargs):
         logger.debug(('exec_module %s'
@@ -230,6 +235,7 @@ def wrap_exec_module(exec_module):
                      kwargs)
         exec_module(*args, **kwargs)
         Recorder().do_import(*args, **kwargs)
+    setattr(wrapped_exec_module, marker, True)
     return wrapped_exec_module
 
 
@@ -255,6 +261,7 @@ def initialize():
     Recorder.initialize()
     if env.enabled():
         wrapped_attr = '_appmap_find_spec'
+        logger.debug('sys.metapath: %s', sys.meta_path)
         for h in sys.meta_path:
             fn = inspect.getattr_static(h, 'find_spec', None)
             if fn is None:

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -3,6 +3,7 @@ import json
 import os
 import sys
 
+from appmap._implementation.recording import Recorder, wrap_exec_module
 from .appmap_test_base import AppMapTestBase
 
 
@@ -35,3 +36,26 @@ class TestRecording(AppMapTestBase):
         generated_appmap = self.normalize_appmap(appmap.generation.dump(r))
 
         assert generated_appmap == expected_appmap
+
+    def test_exec_module_protection(self, monkeypatch):
+        """
+        Test that recording.wrap_exec_module properly protects against
+        rewrapping a wrapped exec_module function.  Repeatedly wrap
+        the function, up to the recursion limit, then call the wrapped
+        function.  If wrapping protection is working properly, there
+        won't be a problem.  If wrapping protection is broken, this
+        test will fail with a RecursionError.
+        """
+
+        def exec_module():
+            pass
+
+        def do_import(*args, **kwargs):  # pylint: disable=unused-argument
+            pass
+        monkeypatch.setattr(Recorder, 'do_import', do_import)
+        f = exec_module
+        for _ in range(sys.getrecursionlimit()):
+            f = wrap_exec_module(f)
+
+        f()
+        assert True


### PR DESCRIPTION
Add an attribute to a wrapped exec_module to make sure
wrap_exec_module doesn't rewrap a metapath finder's exec_module.