### PR TITLE
Clear events list when starting a recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Fixed
+- Fixed a problem where some entry points were missed in shallowly traced packages.
 - Subsequent Recording()s now don't contain previously recorded events.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- Subsequent Recording()s now don't contain previously recorded events.
+
 ### Added
 - Packages in config file can now be set for 'shallow' tracking. This eliminates most of
   the intrapackage execution flow from tracking and produces lighter appmaps where we're

--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -60,8 +60,11 @@ def splitname(obj):
     """
     Given an object that has a __module__ and __qualname__,
     return a list of name components from both.
+    If __module__ is None, 'builtins' is used.
     """
-    return obj.__module__.split('.') + obj.__qualname__.split('.')
+    modname = obj.__module__ or 'builtins'
+
+    return modname.split('.') + obj.__qualname__.split('.')
 
 
 def startswith(prefix, sequence):

--- a/appmap/_implementation/instrument.py
+++ b/appmap/_implementation/instrument.py
@@ -57,17 +57,12 @@ def track_shallow(fn):
     more complicated and can take the performance hit, your best bet is to
     record without shallow and postprocess the appmap to your liking.
     """
+    tls = appmap_tls()
     rule = getattr(fn, '_appmap_shallow', None)
     logger.debug('track_shallow(%r) [%r]', fn, rule)
-    if not rule:
-        return False
-
-    tls = appmap_tls()
-    if tls.get('last_rule', None) == rule:
-        return True
-
+    result = rule and tls.get('last_rule', None) == rule
     tls['last_rule'] = rule
-    return False
+    return result
 
 
 def instrument(fn, fntype):

--- a/appmap/_implementation/recording.py
+++ b/appmap/_implementation/recording.py
@@ -26,13 +26,15 @@ class Recording:
         if not Env.current.enabled:
             return
 
-        Recorder().start_recording()
+        r = Recorder()
+        r.clear()
+        r.start_recording()
 
     def stop(self):
         if not Env.current.enabled:
             return False
 
-        self.events = Recorder().stop_recording()
+        self.events += Recorder().stop_recording()
 
     def __enter__(self):
         self.start()
@@ -152,6 +154,9 @@ class Recorder:
 
     def use_filter(self, filter_class):
         self.filter_stack.append(filter_class)
+
+    def clear(self):
+        self._events = []
 
     def start_recording(self):
         logger.debug('AppMap recording started')

--- a/appmap/test/appmap_test_base.py
+++ b/appmap/test/appmap_test_base.py
@@ -64,6 +64,8 @@ class AppMapTestBase:
         """
 
         def normalize(dct):
+            if 'classMap' in dct:
+                dct['classMap'].sort(key=itemgetter('name'))
             if 'children' in dct:
                 dct['children'].sort(key=itemgetter('name'))
             if 'elapsed' in dct:

--- a/appmap/test/test_configuration.py
+++ b/appmap/test/test_configuration.py
@@ -3,7 +3,7 @@ import os
 
 import appmap
 from .appmap_test_base import AppMapTestBase
-from appmap._implementation.configuration import ConfigFilter
+from appmap._implementation.configuration import ConfigFilter, splitname
 from appmap._implementation.recording import NullFilter
 
 
@@ -99,3 +99,7 @@ class TestConfiguration(AppMapTestBase):
         f.__qualname__ = 'cls.func'
         fltr = ConfigFilter(NullFilter())
         assert not fltr.included(f)
+
+    def test_splitname_works_with_builtins(self):
+        name = '.'.join(splitname(str.maketrans))
+        assert name == 'builtins.str.maketrans'

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -36,6 +36,26 @@ class TestRecording(AppMapTestBase):
 
         assert generated_appmap == expected_appmap
 
+    @pytest.mark.usefixtures('appmap_enabled')
+    def test_recording_clears(self):
+        from example_class import ExampleClass  # pylint: disable=import-error
+
+        with appmap.Recording():
+            ExampleClass.static_method()
+
+        # fresh recording shouldn't contain previous traces
+        rec = appmap.Recording()
+        with rec:
+            ExampleClass.class_method()
+
+        assert rec.events[0].method_id == 'class_method'
+
+        # but it can be added to
+        with rec:
+            ExampleClass().instance_method()
+
+        assert rec.events[2].method_id == 'instance_method'
+
     def test_exec_module_protection(self, monkeypatch):
         """
         Test that recording.wrap_exec_module properly protects against

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -56,6 +56,18 @@ class TestRecording(AppMapTestBase):
 
         assert rec.events[2].method_id == 'instance_method'
 
+    @pytest.mark.usefixtures('appmap_enabled')
+    def test_recording_shallow(self):
+        from example_class import ExampleClass  # pylint: disable=import-error
+        rec = appmap.Recording()
+        with rec:
+            ExampleClass.class_method()
+            ExampleClass().instance_method()
+            ExampleClass.class_method()
+            ExampleClass().instance_method()
+
+        assert len(rec.events) == 8
+
     def test_exec_module_protection(self, monkeypatch):
         """
         Test that recording.wrap_exec_module properly protects against


### PR DESCRIPTION
This should fix a problem where unrelated events end up in test appmaps.