### PR TITLE
Add appmap.labels decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   
 ### Fixed
 - [#61] Don't modify an instrumented function's parameters when rendering them.
+- Correct the structure of the `return_value` object in a `return` event.
+
 ## [0.5.0] - 2021-03-08
 ### Added
 - Packages in config file can now be set for 'shallow' tracking. This eliminates most of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- The `appmap.labels` decorator can now be applied to a function to specify labels that
+  should appear in the AppMap.
+  
 ## [0.5.0] - 2021-03-08
 ### Added
 - Packages in config file can now be set for 'shallow' tracking. This eliminates most of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `appmap.labels` decorator can now be applied to a function to specify labels that
   should appear in the AppMap.
   
+### Fixed
+- [#61] Don't modify an instrumented function's parameters when rendering them.
 ## [0.5.0] - 2021-03-08
 ### Added
 - Packages in config file can now be set for 'shallow' tracking. This eliminates most of

--- a/README.md
+++ b/README.md
@@ -1,4 +1,27 @@
-## About
+- [About](#about)
+  - [Supported versions](#supported-versions)
+- [Installation](#installation)
+- [Configuration](#configuration)
+  - [Environment Variables](#environment-variables)
+- [Labels](#labels)
+- [Test Frameworks](#test-frameworks)
+  - [pytest](#pytest)
+  - [unittest](#unittest)
+  - [Run your tests](#run-your-tests)
+- [Remote Recording [coming soon]](#remote-recording-coming-soon)
+  - [Django](#django)
+  - [Flask](#flask)
+  - [Run your web app](#run-your-web-app)
+- [Context manager](#context-manager)
+- [Development](#development)
+  - [Python version support](#python-version-support)
+  - [Dependency management](#dependency-management)
+  - [Linting](#linting)
+  - [Testing](#testing)
+    - [pytest](#pytest-1)
+    - [tox](#tox)
+  - [Code Coverage](#code-coverage)
+# About
 `appmap-python` is a Python package for recording
 [AppMaps](https://github.com/applandinc/appmap) of your code. "AppMap" is a data format
 which records code structure (modules, classes, and methods), code execution events
@@ -28,14 +51,14 @@ for VSCode](https://marketplace.visualstudio.com/items?itemName=appland.appmap).
 The second option is to upload them to the [AppLand server](https://app.land) using the
 [AppLand CLI](https://github.com/applandinc/appland-cli/releases).
 
-### Supported versions
+## Supported versions
 
 * Python >=3.5
 * Pytest >=6.1.2
 
 Support for new versions is added frequently, please check back regularly for updates.
 
-## Installation
+# Installation
 
 If your project uses `pip` for dependency management, add the `appmap` package to the requirements
 file or install it directly with
@@ -45,7 +68,7 @@ pip install appmap
 
 For projects that use `poetry` , add the `appmap` package to `pyproject.toml`.
 
-## Configuration
+# Configuration
 Add your modules as `path` entries in `appmap.yml`, and external packages
 (distributions) as `dist`:
 
@@ -93,11 +116,42 @@ You can also use `shallow: true` on `path` entries.
 * `APPMAP_OUTPUT_DIR` specifies the root directory for writing AppMaps. Defaults to
   `tmp/appmap`.
 
-## Test Frameworks
+
+# Labels
+
+The [AppMap data format](https://github.com/applandinc/appmap) provides for class and
+function `labels`, which can be used to enhance the AppMap visualizations, and to
+programatically analyze the data.
+
+You can apply function labels using the `appmap.labels` decorator in your Python code. To
+apply a labels to a function, decorate the function with `@appmap.labels`.
+
+For example
+
+```python
+import appmap.labels
+
+class ApiKey
+  @appmap.labels('provider.authentication', 'security')
+  def authenticate(self, key):
+      # logic to verify the key here...
+```
+
+Then the AppMap metadata section for this function will include:
+
+```json
+  {
+    "name": "authenticate",
+    "type": "function",
+    "labels": [ "provider.authentication", "security" ]
+  }
+```
+
+# Test Frameworks
 `appmap-python` supports recording [pytest](https://pytest.org) and
 [unittest](https://docs.python.org/3/library/unittest.html) test cases.
 
-### pytest
+## pytest
 `appmap-python` is a `pytest` plugin. When it's installed in a project that uses
 `pytest`, it will be available to generate AppMaps.
 
@@ -135,13 +189,13 @@ PASSED
 ====================================================================== 1 passed in 0.45s ======================================================================
 ```
 
-### unittest
+## unittest
 `import appmap.unittest`. Instruments subclasses of `unittest.TestCase` and records each
 `test_*` function in the subclasses. You can also use `python -m appmap.unittest` exactly like
 `python -m unittest` and leave your code unmodified (just remember to set the `APPMAP=true`
 environment variable).
 
-### Run your tests
+## Run your tests
 Once you've configured your tests to generate AppMaps, run the tests with the
 `APPMAP=true` in the environment. For example, to run a pytest test suite:
 
@@ -150,17 +204,17 @@ $ APPMAP=true pytest
 ```
 
 
-## Remote Recording [coming soon]
+# Remote Recording [coming soon]
 `appmap-python` supports remote recording of Django and Flask web applications. Import the
 appropriate remote recording support into your web app.
 
-### Django
+## Django
 `import appmap.django`. Adds `/_appmap/record` routes to a Django app.
 
-### Flask
+## Flask
 `import appmap.flask`. Adds `/_appmap/record` routes to a Flask app.
 
-### Run your web app
+## Run your web app
 Once you've configured your web app to add the remote-recording routes, you can use the
 routes to manage recordings. The browser extension, appland CLI, or just plain cURL will
 all work for this.
@@ -196,7 +250,7 @@ An app with remote recording enabled supports these routes:
   200 with AppMap as body
   404 if there's no recording in progress
 
-## Context manager
+# Context manager
 You can use `appmap.record` as a context manager to record your code.
 
 With a file called `record_sample.py` like this
@@ -255,11 +309,11 @@ you can generate a recording of the code
       "name": "appmap",
 ```
 
-## Development
+# Development
 
 [![Build Status](https://travis-ci.com/applandinc/appmap-python.svg?branch=master)](https://travis-ci.com/applandinc/appmap-python)
 
-### Python version support
+## Python version support
 As a package intended to be installed in as many environments as possible, `appmap-python`
 needs to avoid using features of Python or the standard library that were added after the
 oldest version currently supported (see [above](#supported-version)).
@@ -269,7 +323,7 @@ use of some invalid features. Additionally, tests are run using all supported ve
 Python.
 
 
-### Dependency management
+## Dependency management
 
 [poetry](https://https://python-poetry.org/) for dependency management:
 
@@ -279,7 +333,7 @@ Python.
 % poetry install
 ```
 
-### Linting
+## Linting
 [pylint](https://www.pylint.org/) for linting:
 
 ```
@@ -296,8 +350,8 @@ this easier to achieve, convention and refactoring checks have both been disable
 should be reenabled as soon as possible.]
 
 
-### Testing
-#### pytest
+## Testing
+### pytest
 [pytest](https://docs.pytest.org/en/stable/) for testing:
 
 ```
@@ -305,7 +359,7 @@ should be reenabled as soon as possible.]
 % poetry run pytest
 ```
 
-#### tox
+### tox
 Additionally, the `tox` configuration provides the ability to run the tests for all
 supported versions of Python and django:
 
@@ -318,7 +372,7 @@ Note that `tox` requires the correct version of Python to be installed before it
 create a test environment. [pyenv](https://github.com/pyenv/pyenv) is an easy way to
 manage multiple versions of Python.
 
-### Code Coverage
+## Code Coverage
 [coverage](https://coverage.readthedocs.io/) for coverage:
 
 ```

--- a/appmap/__init__.py
+++ b/appmap/__init__.py
@@ -1,8 +1,10 @@
 """AppMap recorder for Python"""
 
-from ._implementation.env import Env # noqa; F401
+
+from ._implementation.env import Env  # noqa: F401
 from ._implementation.recording import Recording, instrument_module  # noqa: F401
 from ._implementation import generation  # noqa: F401
+from ._implementation.labels import labels  # noqa: F401
 
 
 def enabled():

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -165,14 +165,14 @@ class CallEvent(Event):
                 # A 'req' argument can be either keyword or
                 # positional.
                 if p.name in kwargs:
-                    value = kwargs.pop(p.name)
+                    value = kwargs[p.name]
                 else:
                     value = args[0]
                     args = args[1:]
             elif p.kind == 'keyreq':
-                value = kwargs.pop(p.name)
+                value = kwargs[p.name]
             elif p.kind == 'opt' or p.kind == 'key':
-                value = kwargs.pop(p.name, p.default)
+                value = kwargs.get(p.name, p.default)
             elif p.kind == 'rest':
                 value = args
             elif p.kind == 'keyrest':

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -62,6 +62,13 @@ def display_string(val):
     return value
 
 
+def describe_value(val):
+    return {
+        "class": fqname(type(val)),
+        "object_id": id(val),
+        "value": display_string(val)
+    }
+
 class Event:
     __slots__ = ['id', 'event', 'thread_id']
 
@@ -106,16 +113,12 @@ class Param:
         return '<Param name: %s kind: %s>' % (self.name, self.kind)
 
     def to_dict(self, value):
-        class_name = fqname(type(value))
-        object_id = id(value)
-
-        return {
+        ret = {
             "name": self.name,
-            "class": class_name,
-            "value": display_string(value),
-            "object_id": object_id,
             "kind": self.kind
         }
+        ret.update(describe_value(value))
+        return ret
 
 
 class CallEvent(Event):
@@ -235,7 +238,7 @@ class FuncReturnEvent(ReturnEvent):
 
     def __init__(self, parent_id, elapsed, return_value):
         super().__init__(parent_id, elapsed)
-        self.return_value = display_string(return_value)
+        self.return_value = describe_value(return_value)
 
 
 class HttpResponseEvent(ReturnEvent):

--- a/appmap/_implementation/generation.py
+++ b/appmap/_implementation/generation.py
@@ -28,21 +28,28 @@ class ClassMapEntry:
         # actually be a problem, of course.
         self.type = type
 
+    def to_dict(self):
+        return {k: v for k, v in vars(self).items() if v is not None}
+
+
 class PackageEntry(ClassMapEntry):
     def __init__(self, name):
         super().__init__(name, 'package')
         self.children = ClassMapDict()
+
 
 class ClassEntry(ClassMapEntry):
     def __init__(self, name):
         super().__init__(name, 'class')
         self.children = ClassMapDict()
 
+
 class FuncEntry(ClassMapEntry):
     def __init__(self, e):
         super().__init__(e.method_id, 'function')
         self.location = '%s:%s' % (e.path, e.lineno)
         self.static = e.static
+        self.labels = e.labels
 
 
 def classmap(recording):
@@ -91,7 +98,7 @@ class AppMapEncoder(json.JSONEncoder):
         elif isinstance(o, ClassMapDict):
             return list(o.values())
         elif isinstance(o, ClassMapEntry):
-            return vars(o)
+            return o.to_dict()
 
         return json.JSONEncoder.default(self, o)
 

--- a/appmap/_implementation/labels.py
+++ b/appmap/_implementation/labels.py
@@ -1,0 +1,11 @@
+
+
+class labels:
+    def __init__(self, *args):
+        self._labels = args
+
+    def __call__(self, fn):
+        # For simplicity, set _appmap_labels right on the
+        # function. We'll delete it when we instrument the function.
+        setattr(fn, '_appmap_labels', self._labels)
+        return fn

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -1,6 +1,9 @@
 import time
 import yaml
 
+import appmap
+
+
 class ClassMethodMixin:
     @classmethod
     def class_method(cls):
@@ -30,3 +33,7 @@ class ExampleClass(Super, ClassMethodMixin):
         raise Exception('test exception')
 
     what_time_is_it = time.gmtime
+
+    @appmap.labels('super', 'important')
+    def labeled_method(self):
+        return 'super important'

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -116,14 +116,20 @@
       "parent_id": 3,
       "id": 4,
       "event": "return",
-      "return_value": "None",
-      "thread_id": 1
+      "return_value": {
+        "class": "builtins.NoneType",
+        "value": "None"
+      },
+       "thread_id": 1
     },
     {
       "parent_id": 2,
       "id": 5,
       "event": "return",
-      "return_value": "ExampleClass.static_method\n...\n",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "ExampleClass.static_method\n...\n"
+      },
       "thread_id": 1
     },
     {
@@ -147,7 +153,10 @@
       "parent_id": 6,
       "id": 7,
       "event": "return",
-      "return_value": "ClassMethodMixin#class_method, cls ExampleClass",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "ClassMethodMixin#class_method, cls ExampleClass"
+      },
       "thread_id": 1
     },
     {
@@ -171,7 +180,10 @@
       "parent_id": 8,
       "id": 9,
       "event": "return",
-      "return_value": "Super#instance_method",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "Super#instance_method"
+      },
       "thread_id": 1
     },
     {

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -21,7 +21,7 @@
             {
               "name": "class_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:5",
+              "location": "appmap/test/data/example_class.py:8",
               "static": true
             }
           ]
@@ -33,13 +33,13 @@
             {
               "name": "static_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:22",
+              "location": "appmap/test/data/example_class.py:25",
               "static": true
             },
             {
               "name": "test_exception",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:29",
+              "location": "appmap/test/data/example_class.py:32",
               "static": false
             }
           ]
@@ -51,7 +51,7 @@
             {
               "name": "instance_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:11",
+              "location": "appmap/test/data/example_class.py:14",
               "static": false
             }
           ]
@@ -88,7 +88,7 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "static_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 22,
+      "lineno": 25,
       "static": true,
       "parameters": [],
       "id": 2,
@@ -130,7 +130,7 @@
       "defined_class": "example_class.ClassMethodMixin",
       "method_id": "class_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 5,
+      "lineno": 8,
       "static": true,
       "receiver": {
         "class": "builtins.type",
@@ -154,7 +154,7 @@
       "defined_class": "example_class.Super",
       "method_id": "instance_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 11,
+      "lineno": 14,
       "static": false,
       "receiver": {
         "class": "example_class.ExampleClass",
@@ -178,7 +178,7 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "test_exception",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 29,
+      "lineno": 32,
       "static": false,
       "receiver": {
         "class": "example_class.ExampleClass",

--- a/appmap/test/data/pytest/expected.appmap.json
+++ b/appmap/test/data/pytest/expected.appmap.json
@@ -59,7 +59,11 @@
       "parent_id": 3,
       "id": 4,
       "event": "return",
-      "return_value": "Hello",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "Hello"
+      },
+
       "thread_id": 1
     },
     {
@@ -83,14 +87,20 @@
       "parent_id": 5,
       "id": 6,
       "event": "return",
-      "return_value": "world!",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "world!"
+      },
       "thread_id": 1
     },
     {
       "parent_id": 2,
       "id": 7,
       "event": "return",
-      "return_value": "Hello world!",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "Hello world!"
+      },
       "thread_id": 1
     }
   ],

--- a/appmap/test/data/pytest/expected.unittest.appmap.json
+++ b/appmap/test/data/pytest/expected.unittest.appmap.json
@@ -64,7 +64,10 @@
       "parent_id": 3,
       "id": 4,
       "event": "return",
-      "return_value": "Hello",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "Hello"
+      },
       "thread_id": 1
     },
     {
@@ -88,14 +91,20 @@
       "parent_id": 5,
       "id": 6,
       "event": "return",
-      "return_value": "world!",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "world!"
+      },
       "thread_id": 1
     },
     {
       "parent_id": 2,
       "id": 7,
       "event": "return",
-      "return_value": "Hello world!",
+      "return_value": {
+        "class": "builtins.str",
+        "value": "Hello world!"
+      },
       "thread_id": 1
     }
   ],

--- a/appmap/test/test_labels.py
+++ b/appmap/test/test_labels.py
@@ -1,0 +1,34 @@
+from functools import partialmethod
+
+import pytest
+
+import appmap
+from appmap._implementation import generation
+
+from .appmap_test_base import AppMapTestBase
+
+
+class TestLabels(AppMapTestBase):
+    @pytest.mark.usefixtures('appmap_enabled')
+    def test_labeled_function(self, monkeypatch):
+
+        def check_labels(self, to_dict):
+            if self.name == 'labeled_method':
+                assert list(self.labels) == ['super', 'important']
+            elif self.name == 'instance_method':
+                assert not self.labels
+            ret = to_dict(self)
+            return ret
+
+        monkeypatch.setattr(generation.FuncEntry, 'to_dict',
+                            partialmethod(
+                                check_labels,
+                                generation.FuncEntry.to_dict))
+
+        from example_class import ExampleClass  # pylint: disable=import-error
+        rec = appmap.Recording()
+        with rec:
+            ExampleClass().labeled_method()
+            ExampleClass().instance_method()
+
+        generation.dump(rec)


### PR DESCRIPTION
Provide the `labels` decorator to allow the user to add annotations
(labels) to the classMap entries for functions.

Also, get rid of some code that modified an instrumented function's kwargs. Fixes #61.