### PR TITLE
Add APPMAP_DISPLAY_PARAMS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,60 +1,30 @@
 language: python
-python:
-- "3.9"
+python: 3.9
 
-stages:
-- lint
-- test
-- deploy
+env:
+- PYENV_ROOT="$HOME/.pyenv"
+
+install: |
+  if [[ ! -d "$PYENV_ROOT/versions" ]]; then
+    rmdir "$PYENV_ROOT"
+    curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash
+  fi
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  pyenv update
+  git clone https://github.com/momo-lab/xxenv-latest.git "$(pyenv root)/plugins/xxenv-latest"
+  for v in {5..9}; do pyenv latest install -s 3.$v; pyenv latest uninstall -f 3.$v; done
+  pyenv latest local 3.{9,{5..8}}
+  pip install --upgrade pip
+  pip install poetry tox
+
+
 cache:
-  pip: true
-  
-install:
-- pip install --upgrade pip
-- pip install poetry
-- poetry install
+- $PYENV_ROOT
+- $HOME/build/applandinc/appmap-python/.tox/
 
-jobs:
-  include:
-  - stage: lint
-    script:
-    - poetry run pylint appmap
-    - poetry run vermin -t=3.5- appmap
-    
-  - stage: test
-    python: "3.5"
-    script:
-    - poetry run tox
-  - stage: test
-    python: "3.6"
-    script:
-    - poetry run tox
-  - stage: test
-    python: "3.7"
-    script:
-    - poetry run tox
-  - stage: test
-    python: "3.8"
-    script:
-    - poetry run tox
-  - stage: test
-    python: "3.9"
-    script:
-    - poetry run tox
-
-  - stage: deploy
-    script: skip
-    before_deploy:
-    - awk -i inplace -v travis_tag=$TRAVIS_TAG '/# @@appmap-python-version@@/ {getline; printf("version = \"%s\"\n", travis_tag)}; !/version = "0.0.0"/ {print $0}' pyproject.toml
-    # Note publishing this way requires the PyPI credentials to be
-    # present in the environment. Travis doesn't currently support
-    # providing environment variables to deploy providers through
-    # the build config (i.e. in this file). So, they must be
-    # provided through the build settings instead.
-    deploy:
-      # Don't undo the changes we just made to pyproject.toml
-      skip_cleanup: true
-      provider: script
-      script: poetry publish --build
-      on:
-        tags: true
+script:
+- export PATH="$HOME/.pyenv/bin:$PATH"
+- eval "$(pyenv init -)"
+- eval "$(pyenv virtualenv-init -)"
+- tox -e py39 pylint appmap
+- tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,5 @@ script:
 - export PATH="$HOME/.pyenv/bin:$PATH"
 - eval "$(pyenv init -)"
 - eval "$(pyenv virtualenv-init -)"
-- tox -e py39 pylint appmap
+- tox -e py39 pylint appmap || travis_terminate 1
 - tox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [#68] Support `APPMAP_DISPLAY_PARAMS`.
 
 ## [0.8.0.dev1] - 2021-03-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#68] Support `APPMAP_DISPLAY_PARAMS`.
 
+### Fixed
+- [#69] django integration handles responses with missing `Content-Type`.
+
 ## [0.8.0.dev1] - 2021-03-25
 ### Added
 - [#66] Path and line number of test function is now included in AppMap metadata, as

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ You can also use `shallow: true` on `path` entries.
 * `APPMAP_OUTPUT_DIR` specifies the root directory for writing AppMaps. Defaults to
   `tmp/appmap`.
 
+* `APPMAP_DISPLAY_PARAMS` enables rendering of parameters as strings. If `true` (the
+  default, not case-sensitive), parameters are rendered using `str` and/or `repr`. If
+  `false`, a generic string is used instead.
 
 # Labels
 

--- a/appmap/_implementation/env.py
+++ b/appmap/_implementation/env.py
@@ -34,6 +34,9 @@ class Env(metaclass=_EnvMeta):
 
         _configure_logging()
 
+        self._display_params = (
+            os.getenv("APPMAP_DISPLAY_PARAMS", "true").lower() == "true")
+
     @property
     def root_dir(self):
         return self._root_dir
@@ -52,6 +55,10 @@ class Env(metaclass=_EnvMeta):
         # toggle the state of enabled by changing the value of APPMAP
         # in environment. So, don't cache it for now.
         return os.getenv("APPMAP", "false") == "true"
+
+    @property
+    def display_params(self):
+        return self._display_params
 
 
 def _configure_logging():

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -5,6 +5,7 @@ from itertools import chain
 import logging
 import threading
 
+from .env import Env
 from .utils import (
     appmap_tls,
     get_function_location,
@@ -51,18 +52,24 @@ class _EventIds:
 
 
 def display_string(val):
-    # Make a best-effort attempt to get a string value for the
-    # parameter. If str() and repr() raise, formulate a value from
-    # the class and id.
-    try:
-        value = str(val)
-    except Exception:  # pylint: disable=broad-except
+    # If we're asked to display parameters, make a best-effort attempt
+    # to get a string value for the parameter using str() and
+    # repr(). If parameter display is disabled, or str() and repr()
+    # both raised, just formulate a value from the class and id.
+    value = None
+    if Env.current.display_params:
         try:
-            value = repr(val)
+            value = str(val)
         except Exception:  # pylint: disable=broad-except
-            class_name = fqname(type(val))
-            object_id = id(val)
-            value = '<%s object at %#02x>' % (class_name, object_id)
+            try:
+                value = repr(val)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    if value is None:
+        class_name = fqname(type(val))
+        object_id = id(val)
+        value = '<%s object at %#02x>' % (class_name, object_id)
 
     return value
 

--- a/appmap/django.py
+++ b/appmap/django.py
@@ -72,7 +72,7 @@ class Middleware:
                 parent_id=call_event.id,
                 elapsed=duration,
                 status_code=response.status_code,
-                mime_type=response['Content-Type']
+                mime_type=response.get('Content-Type', None) or 'unknown'
             )
             self.recorder.add_event(return_event)
 

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -64,3 +64,6 @@ class ExampleClass(Super, ClassMethodMixin):
     @wrap_fn
     def wrapped_instance_method(self):
         return 'wrapped_instance_method'
+
+    def instance_with_param(self, p):
+        return p

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,4 @@ envlist = py3{5,6,7,8,9}
 whitelist_externals = poetry
 commands =
     poetry install -v
-    poetry run pytest {posargs}
+    poetry run {posargs:pytest}


### PR DESCRIPTION
Fixes #68 by adding support for `APPMAP_DISPLAY_PARAMS`.

Fixes #69 by handling HTTP responses that don't have `Content-Type`.

Also, rework the Travis build config so it can cache dependencies. This reduces the build time from 17-20min to ~3min when the cache is available (which it should be for most builds, once this gets merged).