### PR TITLE
Reset shallow tracking rule when a function returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [#72] Multiple calls into a shallow-tracked package are now recorded.
+- [#74] pytest integration works again
 
 ## [0.8.0.dev2] - 2021-03-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#72] Multiple calls into a shallow-tracked package are now recorded.
+
 ## [0.8.0.dev2] - 2021-03-26
 ### Added
 - [#68] Support `APPMAP_DISPLAY_PARAMS`.

--- a/appmap/_implementation/instrument.py
+++ b/appmap/_implementation/instrument.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from contextlib import contextmanager
 from functools import wraps, WRAPPER_ASSIGNMENTS
 import logging
@@ -31,31 +32,20 @@ def track_shallow(fn):
     Check if the function should be skipped because of a shallow rule.
     If not, updates the last rule tracking and return False.
 
-    Note this works by remembering last matched rule. This is rather simple
-    and the results are not always correct. Consider for example:
+    This works by remembering last matched rule.  This is rather
+    simple and the results are not always correct.  For example,
+    consider execution flow where code matching another shallow rule
+    repeatedly gets called from the code that's already shallow.  It's
+    difficult, if at all possible, to generally ensure correctness
+    without tracking all execution or analyzing the call stack on each
+    call, which is probably too inefficient.
 
-        def fun1(): fun2()
-        def fun2(): pass
-
-        fun1()
-        fun2()
-
-    In this case, the first call to fun2() (from inside fun1()) should be
-    skipped, but the second one should not. Since we only track last matched
-    rule, we won't notice we're back at toplevel and the second fun2() call
-    would be lost.
-
-    There are more corner cases (for example consider execution flow where
-    code matching another shallow rule repeatedly gets called from
-    the code that's already shallow) and it's difficult, if at all possible, to
-    generally ensure correctness without tracking all execution or analyzing
-    the call stack on each call, which is probably too inefficient.
-
-    However, in the most useful case where we're interested in the interaction
-    between client code and specific third-party libraries while ignoring their
-    internals, it's an effective way of limiting appmap size. If you want anything
-    more complicated and can take the performance hit, your best bet is to
-    record without shallow and postprocess the appmap to your liking.
+    However, in the most useful case where we're interested in the
+    interaction between client code and specific third-party libraries
+    while ignoring their internals, it's an effective way of limiting
+    appmap size.  If you want anything more complicated and can take
+    the performance hit, your best bet is to record without shallow
+    and postprocess the appmap to your liking.
     """
     tls = appmap_tls()
     rule = getattr(fn, '_appmap_shallow', None)
@@ -63,6 +53,56 @@ def track_shallow(fn):
     result = rule and tls.get('last_rule', None) == rule
     tls['last_rule'] = rule
     return result
+
+
+@contextmanager
+def saved_shallow_rule():
+    """
+    A context manager to save and reset the current shallow tracking
+    rule around the call to an instrumented function.
+    """
+    tls = appmap_tls()
+    current_rule = tls.get('last_rule', None)
+    try:
+        yield
+    finally:
+        tls['last_rule'] = current_rule
+
+
+_InstrumentedFn = namedtuple('_InstrumentedFn',
+                             'fn, instrumented_fn, make_call_event, params')
+
+
+def call_instrumented(f, *args, **kwargs):
+    if (
+        (not Recorder().enabled)
+        or is_instrumentation_disabled()
+        or track_shallow(f.instrumented_fn)
+    ):
+        return f.fn(*args, **kwargs)
+
+    with recording_disabled():
+        logger.debug('%s args %s kwargs %s', f.fn, args, kwargs)
+        call_event = f.make_call_event(
+            parameters=CallEvent.set_params(f.params, args, kwargs))
+    call_event_id = call_event.id
+    Recorder().add_event(call_event)
+    start_time = time.time()
+    try:
+        ret = f.fn(*args, **kwargs)
+        elapsed_time = time.time() - start_time
+
+        return_event = event.FuncReturnEvent(return_value=ret,
+                                             parent_id=call_event_id,
+                                             elapsed=elapsed_time)
+        Recorder().add_event(return_event)
+        return ret
+    except Exception:  # noqa: E722
+        elapsed_time = time.time() - start_time
+        Recorder().add_event(event.ExceptionEvent(parent_id=call_event_id,
+                                                  elapsed=elapsed_time,
+                                                  exc_info=sys.exc_info()))
+        raise
 
 
 def instrument(fn, fntype):
@@ -80,34 +120,9 @@ def instrument(fn, fntype):
     # Going forward, we should consider how to make this more general.
     @wraps(fn, assigned=WRAPPER_ASSIGNMENTS + tuple(['cache_clear']))
     def instrumented_fn(*args, **kwargs):
-        if (
-            (not Recorder().enabled)
-            or is_instrumentation_disabled()
-            or track_shallow(instrumented_fn)
-        ):
-            return fn(*args, **kwargs)
+        with saved_shallow_rule():
+            f = _InstrumentedFn(fn, instrumented_fn, make_call_event, params)
+            return call_instrumented(f, *args, **kwargs)
 
-        with recording_disabled():
-            logger.debug('%s args %s kwargs %s', fn, args, kwargs)
-            call_event = make_call_event(
-                parameters=CallEvent.set_params(params, args, kwargs))
-        call_event_id = call_event.id
-        Recorder().add_event(call_event)
-        start_time = time.time()
-        try:
-            ret = fn(*args, **kwargs)
-            elapsed_time = time.time() - start_time
-
-            return_event = event.FuncReturnEvent(return_value=ret,
-                                                 parent_id=call_event_id,
-                                                 elapsed=elapsed_time)
-            Recorder().add_event(return_event)
-            return ret
-        except Exception:  # noqa: E722
-            elapsed_time = time.time() - start_time
-            Recorder().add_event(event.ExceptionEvent(parent_id=call_event_id,
-                                                      elapsed=elapsed_time,
-                                                      exc_info=sys.exc_info()))
-            raise
     setattr(instrumented_fn, '_appmap_wrapped', True)
     return instrumented_fn

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -1,6 +1,6 @@
 from functools import wraps
 import time
-import yaml
+
 
 import appmap
 
@@ -35,9 +35,9 @@ class ExampleClass(Super, ClassMethodMixin):
     def __repr__(self):
         return 'ExampleClass and %s' % (self.another_method())
 
-    @staticmethod
-    def static_method():
-        return yaml.dump('ExampleClass.static_method')
+    # Include some lines so the line numbers in the expected appmap
+    # don't change:
+    # <blank>
 
     def another_method(self):
         return "ExampleClass#another_method"
@@ -67,3 +67,26 @@ class ExampleClass(Super, ClassMethodMixin):
 
     def instance_with_param(self, p):
         return p
+
+    @staticmethod
+    def static_method():
+        import yaml
+        return yaml.dump('ExampleClass.static_method')
+
+    @staticmethod
+    def call_yaml():
+        return ExampleClass.dump_yaml('ExampleClass.call_yaml')
+
+    @staticmethod
+    def dump_yaml(data):
+        import io
+        from yaml import Dumper
+        stream = io.StringIO()
+        dumper = Dumper(stream)
+        try:
+            dumper.open()
+            dumper.represent(data)
+            dumper.close()
+        finally:
+            dumper.dispose()
+        return stream.getvalue()

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -70,8 +70,8 @@ class ExampleClass(Super, ClassMethodMixin):
 
     @staticmethod
     def static_method():
-        import yaml
-        return yaml.dump('ExampleClass.static_method')
+        import yaml, io # Formatting is funky to minimize changes to expected appmap
+        yaml.Dumper(io.StringIO()).open(); return 'ExampleClass.static_method\n...\n'
 
     @staticmethod
     def call_yaml():

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -75,6 +75,42 @@
       "type": "package",
       "children": [
         {
+          "name": "emitter",
+          "type": "package",
+          "children": [
+            {
+              "name": "Emitter",
+              "type": "class",
+              "children": [
+                {
+                  "name": "dispose",
+                  "type": "function",
+                  "location": "yaml/emitter.py:106",
+                  "static": false
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "representer",
+          "type": "package",
+          "children": [
+            {
+              "name": "BaseRepresenter",
+              "type": "class",
+              "children": [
+                {
+                  "name": "represent",
+                  "type": "function",
+                  "location": "yaml/representer.py:26",
+                  "static": false
+                }
+              ]
+            }
+          ]
+        },
+        {
           "name": "serializer",
           "type": "package",
           "children": [
@@ -82,6 +118,12 @@
               "name": "Serializer",
               "type": "class",
               "children": [
+                {
+                  "name": "close",
+                  "type": "function",
+                  "location": "yaml/serializer.py:36",
+                  "static": false
+                },
                 {
                   "name": "open",
                   "type": "function",
@@ -284,12 +326,100 @@
       "thread_id": 1
     },
     {
+      "defined_class": "yaml.representer.BaseRepresenter",
+      "method_id": "represent",
+      "path": "yaml/representer.py",
+      "lineno": 26,
+      "static": false,
+      "receiver": {
+        "name": "self",
+        "kind": "req",
+        "class": "yaml.dumper.Dumper",
+        "value": "<yaml.dumper.Dumper object at 0xabcdef>"
+      },
+      "parameters": [
+        {
+          "name": "data",
+          "kind": "req",
+          "class": "builtins.str",
+          "value": "ExampleClass.call_yaml"
+        }
+      ],
+      "id": 16,
+      "event": "call",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "class": "builtins.NoneType",
+        "value": "None"
+      },
+      "parent_id": 16,
+      "id": 17,
+      "event": "return",
+      "thread_id": 1
+    },
+    {
+      "defined_class": "yaml.serializer.Serializer",
+      "method_id": "close",
+      "path": "yaml/serializer.py",
+      "lineno": 36,
+      "static": false,
+      "receiver": {
+        "name": "self",
+        "kind": "req",
+        "class": "yaml.dumper.Dumper",
+        "value": "<yaml.dumper.Dumper object at 0xabcdef>"
+      },
+      "parameters": [],
+      "id": 18,
+      "event": "call",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "class": "builtins.NoneType",
+        "value": "None"
+      },
+      "parent_id": 18,
+      "id": 19,
+      "event": "return",
+      "thread_id": 1
+    },
+    {
+      "defined_class": "yaml.emitter.Emitter",
+      "method_id": "dispose",
+      "path": "yaml/emitter.py",
+      "lineno": 106,
+      "static": false,
+      "receiver": {
+        "name": "self",
+        "kind": "req",
+        "class": "yaml.dumper.Dumper",
+        "value": "<yaml.dumper.Dumper object at 0xabcdef>"
+      },
+      "parameters": [],
+      "id": 20,
+      "event": "call",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "class": "builtins.NoneType",
+        "value": "None"
+      },
+      "parent_id": 20,
+      "id": 21,
+      "event": "return",
+      "thread_id": 1
+    },
+    {
       "return_value": {
         "class": "builtins.str",
         "value": "ExampleClass.call_yaml\n...\n"
       },
       "parent_id": 13,
-      "id": 16,
+      "id": 22,
       "event": "return",
       "thread_id": 1
     },
@@ -299,7 +429,7 @@
         "value": "ExampleClass.call_yaml\n...\n"
       },
       "parent_id": 12,
-      "id": 17,
+      "id": 23,
       "event": "return",
       "thread_id": 1
     }

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -31,9 +31,21 @@
           "type": "class",
           "children": [
             {
+              "name": "call_yaml",
+              "type": "function",
+              "location": "appmap/test/data/example_class.py:76",
+              "static": true
+            },
+            {
+              "name": "dump_yaml",
+              "type": "function",
+              "location": "appmap/test/data/example_class.py:80",
+              "static": true
+            },
+            {
               "name": "static_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:38",
+              "location": "appmap/test/data/example_class.py:71",
               "static": true
             },
             {
@@ -88,7 +100,7 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "static_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 38,
+      "lineno": 71,
       "static": true,
       "parameters": [],
       "id": 2,
@@ -214,6 +226,82 @@
           "message": "test exception"
         }
       ]
+    },
+    {
+      "defined_class": "example_class.ExampleClass",
+      "method_id": "call_yaml",
+      "path": "appmap/test/data/example_class.py",
+      "lineno": 76,
+      "static": true,
+      "parameters": [],
+      "id": 12,
+      "event": "call",
+      "thread_id": 1
+    },
+    {
+      "defined_class": "example_class.ExampleClass",
+      "method_id": "dump_yaml",
+      "path": "appmap/test/data/example_class.py",
+      "lineno": 80,
+      "static": true,
+      "parameters": [
+        {
+          "name": "data",
+          "kind": "req",
+          "class": "builtins.str",
+          "value": "ExampleClass.call_yaml"
+        }
+      ],
+      "id": 13,
+      "event": "call",
+      "thread_id": 1
+    },
+    {
+      "defined_class": "yaml.serializer.Serializer",
+      "method_id": "open",
+      "path": "yaml/serializer.py",
+      "lineno": 27,
+      "static": false,
+      "receiver": {
+        "name": "self",
+        "kind": "req",
+        "class": "yaml.dumper.Dumper",
+        "value": "<yaml.dumper.Dumper object at 0xabcdef>"
+      },
+      "parameters": [],
+      "id": 14,
+      "event": "call",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "class": "builtins.NoneType",
+        "value": "None"
+      },
+      "parent_id": 14,
+      "id": 15,
+      "event": "return",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "class": "builtins.str",
+        "value": "ExampleClass.call_yaml\n...\n"
+      },
+      "parent_id": 13,
+      "id": 16,
+      "event": "return",
+      "thread_id": 1
+    },
+    {
+      "return_value": {
+        "class": "builtins.str",
+        "value": "ExampleClass.call_yaml\n...\n"
+      },
+      "parent_id": 12,
+      "id": 17,
+      "event": "return",
+      "thread_id": 1
     }
   ]
 }

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -31,6 +31,7 @@ class TestRecordingWhenEnabled(AppMapTestBase):
                 ExampleClass().test_exception()
             except:  # pylint: disable=bare-except  # noqa: E722
                 pass
+            ExampleClass.call_yaml()
 
         generated_appmap = self.normalize_appmap(appmap.generation.dump(r))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ python = "^3.5"
 PyYAML = "~5.3.0"
 inflection = "~0.3.0"
 importlib-metadata = ">=0.8"
+wrapt = "^1.12.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"


### PR DESCRIPTION
Improve handling of multiple calls into a shallow-tracked package. Fixes #72. (I split the changes into two separate commits to make it easier to understand how the expected appmap changed, so it's probably easier to review them individually.)

These changes also switch to using `wrapt` for wrapping the metapath finder functions, which fixes #74. It's currently hard to test the exact environment that reproduces #74, so I'll look at adding a test in a follow-up PR.

Here are some more details for changes to shallow tracking:
Given these functions in a class
```python
    @staticmethod
    def call_yaml():
        return ExampleClass.dump_yaml('ExampleClass.call_yaml')

    @staticmethod
    def dump_yaml(data):
        import io
        from yaml import Dumper
        stream = io.StringIO()
        dumper = Dumper(stream)
        try:
            dumper.open()
            dumper.represent(data)
            dumper.close()
        finally:
            dumper.dispose()
        return stream.getvalue()
```
a full recording for the `call_yaml` function looks like this:
<img width="1137" alt="image" src="https://user-images.githubusercontent.com/4212483/112998864-6e540f00-913c-11eb-859e-4678bf4892ce.png">

Without this change, a recording that captures the PyYAML dist in shallow mode looks like this:
<img width="1073" alt="image" src="https://user-images.githubusercontent.com/4212483/112999207-c0953000-913c-11eb-8deb-fc84aba02f8c.png">

i.e. only the call to `open` is shown.

With this change, all the calls from `call_yaml` into the PyYAML dist are shown:
<img width="1016" alt="image" src="https://user-images.githubusercontent.com/4212483/112999534-081bbc00-913d-11eb-99d2-98a9c14018a7.png">


