### PR TITLE
Change pytest session hook to pytest_sessionstart

### DIFF
--- a/appmap/pytest.py
+++ b/appmap/pytest.py
@@ -6,7 +6,8 @@ from appmap._implementation import testing_framework
 
 if appmap.enabled():
     @pytest.hookimpl
-    def pytest_runtestloop(session):
+    def pytest_sessionstart(session):
+        """Set up AppMap testing session and associate it with pytest and unittest sessions."""
         # Use the same session for unittest in case there are any unittest.TestCases.
         appmap.unittest.session = session.appmap = testing_framework.session(name='pytest', version=pytest.__version__)
 


### PR DESCRIPTION
Previously used *pytest_runtestloop* stops at first non-*None* result; as a consequence, another plugin (such as *xdist*) might cause skipping our hook. *pytest_sessionstart* doesn't have this problem.

(I ran into this issue when trying to run *saleor* tests with all dev dependencies, including *xdist*, installed. It failed with:
```
    @pytest.hookimpl(hookwrapper=True)
    def pytest_pyfunc_call(pyfuncitem):
>       with pyfuncitem.session.appmap.record(
                pyfuncitem.cls,
                pyfuncitem.name,
                method_id=pyfuncitem.originalname,
                location=pyfuncitem.location):
E               AttributeError: 'Session' object has no attribute 'appmap'

../../.local/lib/python3.9/site-packages/appmap/pytest.py:17: AttributeError
```
.)