### PR TITLE
Use repr() by default for stringification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recording them in the `message` attribute of the `call` event.
 - [#83] Capture HTTP request headers in django and flask.
 - [#53] Module-scoped functions are now recorded.
+### Changed
+- Use repr() instead of str() for object stringification.
 ### Fixed
 - Fixed a crash when HTTP request doesn't match any route in Flask.
 - Avoid capturing SQL queries run when fetching object representation in Django.
@@ -33,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [#65] Wrapped functions with mismatched signatures no longer cause mapping failures.
-  
+
 ## [0.7.0] - 2021-03-15
 ### Added
 - [#2] [#28] Add flask integration
@@ -42,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - The `appmap.labels` decorator can now be applied to a function to specify labels that
   should appear in the AppMap.
-  
+
 ### Fixed
 - [#61] Don't modify an instrumented function's parameters when rendering them.
 - Correct the structure of the `return_value` object in a `return` event.

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -53,18 +53,15 @@ class _EventIds:
 
 def display_string(val):
     # If we're asked to display parameters, make a best-effort attempt
-    # to get a string value for the parameter using str() and
-    # repr(). If parameter display is disabled, or str() and repr()
-    # both raised, just formulate a value from the class and id.
+    # to get a string value for the parameter using repr(). If parameter
+    # display is disabled, or repr() has raised, just formulate a value
+    # from the class and id.
     value = None
     if Env.current.display_params:
         try:
-            value = str(val)
+            value = repr(val)
         except Exception:  # pylint: disable=broad-except
-            try:
-                value = repr(val)
-            except Exception:  # pylint: disable=broad-except
-                pass
+            pass
 
     if value is None:
         class_name = fqname(type(val))

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -24,7 +24,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "ExampleClass.static_method\n...\n"
+        "value": "'ExampleClass.static_method\\n...\\n'"
       },
       "parent_id": 2,
       "id": 3,
@@ -51,7 +51,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "ClassMethodMixin#class_method, cls ExampleClass"
+        "value": "'ClassMethodMixin#class_method, cls ExampleClass'"
       },
       "parent_id": 4,
       "id": 5,
@@ -78,7 +78,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "Super#instance_method"
+        "value": "'Super#instance_method'"
       },
       "parent_id": 6,
       "id": 7,
@@ -136,7 +136,7 @@
           "name": "data",
           "kind": "req",
           "class": "builtins.str",
-          "value": "ExampleClass.call_yaml"
+          "value": "'ExampleClass.call_yaml'"
         }
       ],
       "id": 11,
@@ -154,7 +154,7 @@
           "name": "data",
           "kind": "req",
           "class": "builtins.str",
-          "value": "ExampleClass.call_yaml"
+          "value": "'ExampleClass.call_yaml'"
         },
         {
           "name": "stream",
@@ -182,7 +182,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "ExampleClass.call_yaml\n...\n"
+        "value": "'ExampleClass.call_yaml\\n...\\n'"
       },
       "parent_id": 12,
       "id": 13,
@@ -200,7 +200,7 @@
           "name": "data",
           "kind": "req",
           "class": "builtins.str",
-          "value": "ExampleClass.call_yaml"
+          "value": "'ExampleClass.call_yaml'"
         },
         {
           "name": "stream",
@@ -228,7 +228,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "ExampleClass.call_yaml\n...\n"
+        "value": "'ExampleClass.call_yaml\\n...\\n'"
       },
       "parent_id": 14,
       "id": 15,

--- a/appmap/test/data/pytest/expected.appmap.json
+++ b/appmap/test/data/pytest/expected.appmap.json
@@ -64,7 +64,7 @@
       "event": "return",
       "return_value": {
         "class": "builtins.str",
-        "value": "Hello"
+        "value": "'Hello'"
       },
 
       "thread_id": 1
@@ -92,7 +92,7 @@
       "event": "return",
       "return_value": {
         "class": "builtins.str",
-        "value": "world!"
+        "value": "'world!'"
       },
       "thread_id": 1
     },
@@ -102,7 +102,7 @@
       "event": "return",
       "return_value": {
         "class": "builtins.str",
-        "value": "Hello world!"
+        "value": "'Hello world!'"
       },
       "thread_id": 1
     }

--- a/appmap/test/data/unittest/expected.appmap.json
+++ b/appmap/test/data/unittest/expected.appmap.json
@@ -37,7 +37,7 @@
         "name": "self",
         "kind": "req",
         "class": "simple.test_simple.UnitTestTest",
-        "value": "test_hello_world (simple.test_simple.UnitTestTest)"
+        "value": "<simple.test_simple.UnitTestTest testMethod=test_hello_world>"
       },
       "parameters": [],
       "id": 2,
@@ -60,7 +60,7 @@
         "class": "builtins.str",
         "kind": "req",
         "name": "bang",
-        "value": "!"
+        "value": "'!'"
       }],
       "id": 3,
       "event": "call",
@@ -86,7 +86,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "Hello"
+        "value": "'Hello'"
       },
       "parent_id": 4,
       "id": 5,
@@ -113,7 +113,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "world"
+        "value": "'world'"
       },
       "parent_id": 6,
       "id": 7,
@@ -123,7 +123,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "Hello world!"
+        "value": "'Hello world!'"
       },
       "parent_id": 3,
       "id": 8,

--- a/appmap/test/test_django.py
+++ b/appmap/test/test_django.py
@@ -61,7 +61,7 @@ class TestDjango(AppMapTestBase):
                 'name': 'my_param',
                 'class': 'builtins.str',
                 'object_id': events[0].message[0]['object_id'],
-                'value': 'example'
+                'value': "'example'"
             }
         ]
         assert events[0].http_server_request.items() >= {
@@ -86,7 +86,7 @@ class TestDjango(AppMapTestBase):
                 'name': 'my_param',
                 'class': 'builtins.str',
                 'object_id': events[0].message[0]['object_id'],
-                'value': 'example'
+                'value': "'example'"
             }
         ]
 
@@ -113,7 +113,7 @@ class TestDjango(AppMapTestBase):
                 'name': 'my_param',
                 'class': 'builtins.str',
                 'object_id': events[0].message[0]['object_id'],
-                'value': 'example'
+                'value': "'example'"
             }
         ]
 
@@ -126,7 +126,7 @@ class TestDjango(AppMapTestBase):
                 'name': 'my_param',
                 'class': 'builtins.str',
                 'object_id': events[0].message[0]['object_id'],
-                'value': 'example'
+                'value': "'example'"
             }
         ]
 
@@ -140,7 +140,7 @@ class TestDjango(AppMapTestBase):
                 'name': 'my_param',
                 'class': 'builtins.str',
                 'object_id': events[0].message[0]['object_id'],
-                'value': 'example'
+                'value': "'example'"
             }
         ]
 
@@ -154,7 +154,7 @@ class TestDjango(AppMapTestBase):
                 'name': 'my_param',
                 'class': 'builtins.str',
                 'object_id': events[0].message[0]['object_id'],
-                'value': 'example'
+                'value': "'example'"
             }
         ]
 

--- a/appmap/test/test_params.py
+++ b/appmap/test/test_params.py
@@ -103,7 +103,7 @@ class TestStaticMethods(TestMethodBase):
             'name': 'p',
             'class': 'builtins.str',
             'kind': 'req',
-            'value': 'static'
+            'value': "'static'"
         }
 
 
@@ -124,7 +124,7 @@ class TestClassMethods(TestMethodBase):
             'name': 'p',
             'class': 'builtins.str',
             'kind': 'req',
-            'value': 'cls'
+            'value': "'cls'"
         })
 
 
@@ -140,7 +140,7 @@ class TestInstanceMethods(TestMethodBase):
         })
 
     @pytest.mark.parametrize('params,arg,expected',
-                             [('one', 'world', ('builtins.str', 'world')),
+                             [('one', 'world', ('builtins.str', "'world'")),
                               ('one', None, ('builtins.NoneType', 'None'))],
                              indirect=['params'])
     def test_one_param(self, params, arg, expected):
@@ -156,7 +156,7 @@ class TestInstanceMethods(TestMethodBase):
         })
 
     @pytest.mark.parametrize('params,arg,expected',
-                             [('one', 'world', ('builtins.str', 'world')),
+                             [('one', 'world', ('builtins.str', "'world'")),
                               ('one', None, ('builtins.NoneType', 'None'))],
                              indirect=['params'])
     def test_one_param_kw(self, params, arg, expected):


### PR DESCRIPTION
`repr()` is usually the preferred programmer-friendly way to display an object. `str()` is a user representation (for many different meanings of a user), and as such can sometimes cause an expensive and state-changing stringification.

As an example for how that might be harmful, consider `misago.users.admin.forms.EditUserForm.Meta.__init__`:
https://github.com/rafalp/Misago/blob/da14e8ef712a77603fdfec8bbff67c526c7d0c5c/misago/users/admin/forms.py#L202

This method first delegates to superclass, then calls `profilefields.add_fields_to_admin_form(self.request, self.instance, self)`; `self` here is the form. If the appmap hook tries to use `str()` for stringification of this `form` parameter, this will cause HTML rendering and, before that, form validation. Note this happens before the form is completely constructed; some fields have not been added yet. Consequently a validation error in one of these fields will be missed (as the form had validated itself, even though it wasn't completely constructed); this leads to test failure in https://github.com/rafalp/Misago/blob/da14e8ef712a77603fdfec8bbff67c526c7d0c5c/misago/users/tests/test_twitter_profilefield.py#L51

(I'll also note that several pagefuls of HTML aren't particularly useful when reading an appmap. `<UserFormFinal bound=True, valid=Unknown, fields=([...])>` (ellipsis mine) provided by `repr()` is much more informative.)

Generally, consider that we're often trying to record the values inside method calls; however, inside a method call, any invariants the class might have (and `str()` might rely upon) cannot be guaranteed to hold. `repr()` shouldn't suffer from this issue, as it's routinely used by REPL and, in particular, debuggers, to get the object representation in code paused in embarassing places, and so a reasonable programmer would implement it with as few assumptions (and overhead!) as possible, including the assumption of class invariants being upheld.

(Related to #79.)