### PR TITLE
Avoid capturing queries caused by calling repr()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#53] Module-scoped functions are now recorded.
 ### Fixed
 - Fixed a crash when HTTP request doesn't match any route in Flask.
+- Avoid capturing SQL queries run when fetching object representation in Django.
 
 ## [0.8.0] - 2021-04-04
 ### Fixed


### PR DESCRIPTION
Calling repr() on QuerySet objects in django causes a database query. We don't want these queries to end up in the appmap, since they're not part of the application flow.

Moreover, some tests might record and examine queries using CursorDebugWrapper; we don't want them to see those queries, either.

For an example error caused by this, see https://github.com/rafalp/Misago/blob/da14e8ef712a77603fdfec8bbff67c526c7d0c5c/misago/core/tests/test_chunk_queryset.py#L29 -- this tests counts queries and it fails if it sees additional query caused by us calling repr() on the QuerySet.

Related to #79 .