### PR TITLE
Add SQLAlchemy integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   recording them in the `message` attribute of the `call` event.
 - [#83] Capture HTTP request headers in django and flask.
 - [#53] Module-scoped functions are now recorded.
+- [#64] Capture SQL queries in SQLAlchemy.
 ### Changed
 - Use repr() instead of str() for object stringification.
 ### Fixed

--- a/appmap/flask.py
+++ b/appmap/flask.py
@@ -11,6 +11,14 @@ from appmap._implementation.event import HttpRequestEvent, HttpResponseEvent
 from appmap._implementation.recording import Recorder, Recording
 
 
+try:
+    # pylint: disable=unused-import
+    from . import sqlalchemy  # noqa: F401
+except ImportError:
+    # not using sqlalchemy
+    pass
+
+
 class AppmapFlask:
     def __init__(self, app=None):
         self.app = app

--- a/appmap/sqlalchemy.py
+++ b/appmap/sqlalchemy.py
@@ -1,0 +1,55 @@
+"""SQL statement capture for SQLAlchemy."""
+
+import time
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+from appmap._implementation.event import SqlEvent, ReturnEvent
+from appmap._implementation.instrument import is_instrumentation_disabled
+from appmap._implementation.recording import Recorder
+
+
+@event.listens_for(Engine, 'before_cursor_execute')
+# pylint: disable=too-many-arguments,unused-argument
+def capture_sql_call(conn, cursor, statement, parameters, context, executemany):
+    """Capture SQL query callinto appmap."""
+    recorder = Recorder()
+    if is_instrumentation_disabled():
+        # We must be in the middle of fetching object representation.
+        # Don't record this query in the appmap.
+        pass
+    elif recorder.enabled:
+        if executemany:
+            # Sometimes the same query is executed with different parameter sets.
+            # Instead of substituting them all, just say how many times it was run.
+            try:
+                times = len(parameters)
+            except TypeError:
+                times = '?'
+            sql = '-- %s times\n%s' % (times, statement)
+        else:
+            sql = statement
+        call_event = SqlEvent(sql)
+        recorder.add_event(call_event)
+        setattr(
+            context, 'appmap',
+            { 'start_time': time.monotonic(), 'call_event_id': call_event.id }
+        )
+
+
+@event.listens_for(Engine, 'after_cursor_execute')
+# pylint: disable=too-many-arguments,unused-argument
+def capture_sql(conn, cursor, statement, parameters, context, executemany):
+    """Capture SQL query return into appmap."""
+    recorder = Recorder()
+    if is_instrumentation_disabled():
+        # We must be in the middle of fetching object representation.
+        # Don't record this query in the appmap.
+        pass
+    elif recorder.enabled:
+        stop = time.monotonic()
+        duration = stop - context.appmap['start_time']
+        return_event = ReturnEvent(parent_id=context.appmap['call_event_id'], elapsed=duration)
+        del context.appmap
+        recorder.add_event(return_event)

--- a/appmap/test/test_sqlalchemy.py
+++ b/appmap/test/test_sqlalchemy.py
@@ -1,0 +1,68 @@
+"""Tests for the SQLAlchemy integration."""
+
+import pytest
+
+from sqlalchemy import create_engine
+from sqlalchemy import Table, Column, Integer, String, MetaData, ForeignKey
+
+import appmap.sqlalchemy  # pylint: disable=unused-import
+from .appmap_test_base import AppMapTestBase
+
+
+class TestSQLAlchemy(AppMapTestBase):
+    @staticmethod
+    def test_sql_capture(connection, events):
+        connection.execute('SELECT 1')
+        assert events[0].sql_query['sql'] == 'SELECT 1'
+
+
+    @staticmethod
+    # pylint: disable=unused-argument
+    def test_capture_ddl(events, schema):
+        assert 'CREATE TABLE addresses' in events[-2].sql_query['sql']
+
+
+    # pylint: disable=unused-argument
+    def test_capture_insert(self, connection, schema, events):
+        ins = self.users.insert().values(name='jack', fullname='Jack Jones')
+        connection.execute(ins)
+        assert events[-2].sql_query['sql'] == 'INSERT INTO users (name, fullname) VALUES (?, ?)'
+
+
+    # pylint: disable=unused-argument
+    def test_capture_insert_many(self, connection, schema, events):
+        connection.execute(self.addresses.insert(), [
+           {'user_id': 1, 'email_address' : 'jack@yahoo.com'},
+           {'user_id': 1, 'email_address' : 'jack@msn.com'},
+           {'user_id': 2, 'email_address' : 'www@www.org'},
+           {'user_id': 2, 'email_address' : 'wendy@aol.com'},
+        ])
+        assert events[-2].sql_query['sql'] == \
+            '-- 4 times\nINSERT INTO addresses (user_id, email_address) VALUES (?, ?)'
+
+
+    @staticmethod
+    @pytest.fixture
+    def engine():
+        return create_engine('sqlite:///:memory:')
+
+    @staticmethod
+    @pytest.fixture
+    def connection(engine):
+        return engine.connect()
+
+    metadata = MetaData()
+    users = Table('users', metadata,
+        Column('id', Integer, primary_key=True),
+        Column('name', String),
+        Column('fullname', String),
+    )
+    addresses = Table('addresses', metadata,
+        Column('id', Integer, primary_key=True),
+        Column('user_id', None, ForeignKey('users.id')),
+        Column('email_address', String, nullable=False)
+    )
+
+    @pytest.fixture
+    def schema(self, engine):
+        self.metadata.create_all(engine)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 homepage = "https://github.com/applandinc/appmap-python"
 license = "MIT"
-classifiers = [   
+classifiers = [
         'Development Status :: 4 - Beta',
         'Framework :: Django',
         'Framework :: Django :: 2.2',
@@ -35,7 +35,7 @@ packages = [
     { include = "appmap" },
     { include = "appmap/wrapt/*.py", from="vendor/wrapt/src" }
 ]
-    
+
 [tool.poetry.dependencies]
 python = "^3.5"
 PyYAML = "~5.3.0"
@@ -56,6 +56,10 @@ Django = [
   { version = "^3.1.6", python = "^3.6"}
 ]
 flask = "^1.1.2"
+SQLAlchemy = [
+  { version = "~1.3", python = "< 3.6"},
+  { version = "^1.4.11", python = "^3.6"}
+]
 vermin = "^1.1.0"
 tox = "^3.22.0"
 tox-pyenv = "^1.1.0"


### PR DESCRIPTION
SQL queries are captured as long as `appmap.sqlalchemy` is imported before connections are made. Flask integration tries to import it by default, since both are often used in conjunction.

Note captured SQL is parametrized, for example `INSERT INTO users (name, fullname) VALUES (?, ?)`; this is because of how SQLAlchemy executes SQL -- it's actually sent parametrized to the server, the full substituted SQL is never produced outside the database driver (as far as I can tell). This is in line with SQLAlchemy own logging; it adds another line with values:
```
INFO:sqlalchemy.engine.Engine:INSERT INTO users (name, fullname) VALUES (?, ?)
INFO:sqlalchemy.engine.Engine:[generated in 0.00047s] ('jack', 'Jack Jones')
```

Not sure if we should do the same; it can be added to the SQL as a comment, or we could add this as call parameters.

Fixes #64 .