### PR TITLE
docs: bumping supported python to 3.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The second option is to upload them to the [AppLand server](https://app.land) us
 
 ## Supported versions
 
-* Python >=3.5
+* Python >=3.6
 * Pytest >=6.1.2
 
 Support for new versions is added frequently, please check back regularly for updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -37,7 +36,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 PyYAML = "~5.3.0"
 inflection = "~0.3.0"
 importlib-metadata = ">=0.8"


### PR DESCRIPTION
Updating the documentation, the oldest supported version of Python is now 3.6.