### PR TITLE
Write recordings atomically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ script:
 - tox -e py39 -- vermin -t=3.6- appmap || travis_terminate 1
 - tox
 - poetry build
+- echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
 - ci/test_install.sh
 
 before_deploy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#90] Capture HTTP response headers in django and flask.
 
 ### Changed
+- A recording is now created atomically. It is first written to a temp file, which is then
+  renamed to the final file.
 - Headers such as Host, User-Agent, Authorization and Content-Type are no longer
   filtered out in HTTP event `headers` field.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- A recording is now created atomically. It is first written to a temp file, which is then
+  renamed to the final file.
 ## [0.10.0] - 2021-05-07
 ### Added
 - [#90] Capture HTTP response headers in django and flask.
 
 ### Changed
-- A recording is now created atomically. It is first written to a temp file, which is then
-  renamed to the final file.
 - Headers such as Host, User-Agent, Authorization and Content-Type are no longer
   filtered out in HTTP event `headers` field.
 

--- a/appmap/_implementation/testing_framework.py
+++ b/appmap/_implementation/testing_framework.py
@@ -1,5 +1,7 @@
 import inflection
+import os
 import re
+from tempfile import NamedTemporaryFile
 
 from contextlib import contextmanager
 from pathlib import Path
@@ -124,4 +126,11 @@ class session:
         filename = fi.filename + '.appmap.json'
         metadata = fi.metadata
         metadata.update(self.metadata)
-        (self.appmap_path / filename).write_text(generation.dump(rec, metadata))
+        appmap_json = self.appmap_path / filename
+        with NamedTemporaryFile(mode='w', dir=self.appmap_path, delete=False) as f:
+            f.write(generation.dump(rec, metadata))
+            try:
+                os.remove(appmap_json)
+            except FileNotFoundError:
+                pass
+            os.replace(f.name, appmap_json)

--- a/appmap/_implementation/testing_framework.py
+++ b/appmap/_implementation/testing_framework.py
@@ -129,8 +129,4 @@ class session:
         appmap_json = self.appmap_path / filename
         with NamedTemporaryFile(mode='w', dir=self.appmap_path, delete=False) as f:
             f.write(generation.dump(rec, metadata))
-            try:
-                os.remove(appmap_json)
-            except FileNotFoundError:
-                pass
-            os.replace(f.name, appmap_json)
+        os.replace(f.name, appmap_json)

--- a/appmap/test/test_pytest.py
+++ b/appmap/test/test_pytest.py
@@ -1,27 +1,37 @@
 import os
 import os.path
+from pathlib import Path
 
 import json
+import pytest
 
 from .normalize import normalize_appmap
 
-
-def test_basic_integration(data_dir, testdir):
+@pytest.fixture(autouse=True)
+def setup(testdir):
     testdir.copy_example('pytest')
     testdir.monkeypatch.setenv('APPMAP', 'true')
 
+    testdir.appmap_json = (Path(str(testdir))
+        / 'tmp' / 'appmap'/ 'pytest'/ 'test_hello_world.appmap.json')
+
+def test_basic_integration(data_dir, testdir):
     result = testdir.runpytest('-vv', '-k', 'test_hello_world')
     result.assert_outcomes(passed=1)
-
-    appmap_json = os.path.join(
-        str(testdir),
-        'tmp', 'appmap', 'pytest', 'test_hello_world.appmap.json'
-    )
+    appmap_json = testdir.appmap_json
     with open(appmap_json) as appmap:
         generated_appmap = normalize_appmap(appmap.read())
 
-    appmap_json = os.path.join(data_dir, 'pytest', 'expected.appmap.json')
-    with open(appmap_json) as f:
+    expected_json = os.path.join(data_dir, 'pytest', 'expected.appmap.json')
+    with open(expected_json) as f:
         expected_appmap = json.load(f)
 
     assert generated_appmap == expected_appmap
+
+def test_overwrites_existing(testdir):
+    appmap_json = testdir.appmap_json
+    appmap_json.parent.mkdir(parents=True, exist_ok=True)
+    appmap_json.touch()
+
+    result = testdir.runpytest('-vv', '-k', 'test_hello_world')
+    result.assert_outcomes(passed=1)


### PR DESCRIPTION
When writing a recording, save it to a temp file first, then rename it
to the final file.

Fixes #99.