### PR TITLE
Improve metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ script:
 - eval "$(pyenv init --path)"
 - eval "$(pyenv virtualenv-init -)"
 - tox -e py39 -- pylint appmap || travis_terminate 1
-- tox -e py39 -- vermin -t=3.6- appmap || travis_terminate 1
 - tox
 - poetry build
 - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin

--- a/appmap/_implementation/generation.py
+++ b/appmap/_implementation/generation.py
@@ -89,7 +89,7 @@ def classmap(recording):
 
 
 def appmap(recording, metadata):
-    appmap_metadata = Metadata().to_dict()
+    appmap_metadata = Metadata()
     if metadata:
         appmap_metadata.update(metadata)
 

--- a/appmap/_implementation/metadata.py
+++ b/appmap/_implementation/metadata.py
@@ -8,6 +8,17 @@ from . import utils
 logger = logging.getLogger(__name__)
 
 
+def _lines(text):
+    """Split text into lines, stripping and returning just the nonempty ones.
+
+    Returns None if the result would be empty."""
+
+    lines = [x for x in map(lambda x: x.strip(), text.split('\n')) if len(x) > 0]
+    if len(lines) == 0:
+        return None
+    return lines
+
+
 class Metadata:
     def __init__(self, cwd=None):
         self._cwd = cwd if cwd else os.getcwd()
@@ -55,7 +66,7 @@ class Metadata:
         repository = git('config --get remote.origin.url')
         branch = git('rev-parse --abbrev-ref HEAD')
         commit = git('rev-parse HEAD')
-        status = list(map(lambda x: x.strip(), git('status -s').split('\n')))
+        status = _lines(git('status -s'))
         annotated_tag = git('describe --abbrev=0') or None
         tag = git('describe --abbrev=0 --tags') or None
 

--- a/appmap/test/normalize.py
+++ b/appmap/test/normalize.py
@@ -17,7 +17,7 @@ def normalize_git(git):
     git.pop('repository')
     git.pop('branch')
     git.pop('commit')
-    status = git.pop('status')
+    status = git.pop('status', [])
     assert isinstance(status, list)
     tag = git.pop('tag', None)
     if tag:

--- a/appmap/test/test_metadata.py
+++ b/appmap/test/test_metadata.py
@@ -34,16 +34,16 @@ def tmp_git(git_directory, tmp_path):
 def test_missing_git(git, monkeypatch):
     monkeypatch.setenv('PATH', '')
     try:
-        metadata = Metadata(cwd=git.cwd)
-        assert not metadata._git_available()
+        metadata = Metadata(root_dir=git.cwd)
+        assert 'git' not in metadata
     except FileNotFoundError:
         assert False, "_git_available didn't handle missing git"
 
 
 def test_git_metadata(git):
-    metadata = Metadata(cwd=git.cwd)
-    assert metadata._git_available()  # sanity check
-    git_md = metadata._git_metadata()
+    metadata = Metadata(root_dir=git.cwd)
+    assert 'git' in metadata
+    git_md = metadata['git']
     expected = {
         'repository': 'https://www.example.test/repo.git',
         'branch': 'master',
@@ -72,8 +72,8 @@ def test_tags(git):
     git('rm README.metadata')
     git('commit -m "Removed readme"')
 
-    metadata = Metadata(cwd=git.cwd)
-    git_md = metadata._git_metadata()
+    metadata = Metadata(root_dir=git.cwd)
+    git_md = metadata['git']
 
     assert git_md == {
         'repository': 'https://www.example.test/repo.git',


### PR DESCRIPTION
- Cache git metadata
  This improves performance quite a bit since git doesn't get called several times per test case anymore.
- Streamline metadata tests.
- Skip `status` entry if it would be empty anyway.