### PR TITLE
Use Django cached request body when capturing JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#104] The flask integration now formats parameters in `normalized_path_info` to match
   the appmap spec.
 - Git metadata is now cached, preventing running git several times per test case.
+- Fix a problem with Django JSON parameter capture preventing the application
+  from accessing the request body.
 
 ## [0.10.0] - 2021-05-07
 ### Added

--- a/appmap/_implementation/__init__.py
+++ b/appmap/_implementation/__init__.py
@@ -1,6 +1,7 @@
 from . import configuration
 from . import env as appmapenv
 from . import event
+from . import metadata
 from . import recording
 from .py_version_check import check_py_version
 
@@ -11,6 +12,6 @@ def initialize(env=None):
     event.initialize()
     recording.initialize()
     configuration.initialize()  # needs to be initialized after recording
-
+    metadata.initialize()
 
 initialize()

--- a/appmap/_implementation/metadata.py
+++ b/appmap/_implementation/metadata.py
@@ -131,3 +131,6 @@ class Metadata(dict):
             'commits_since_tag': commits_since_tag,
             'commits_since_annotated_tag': commits_since_annotated_tag
         })
+
+def initialize():
+    Metadata.reset()

--- a/appmap/django.py
+++ b/appmap/django.py
@@ -123,7 +123,10 @@ def request_params(request):
 
     if request.content_type == 'application/json':
         try:
-            params.update(json.load(request))
+            # Note: it's important to use request.body here instead of
+            # directly reading request. This way the application can still
+            # access the body which is now cached in the request object.
+            params.update(json.loads(request.body))
         except (json.decoder.JSONDecodeError, AttributeError):
             pass  # invalid json or not an object
 

--- a/appmap/test/test_django.py
+++ b/appmap/test/test_django.py
@@ -42,6 +42,12 @@ def test_framework_metadata(client, events):  # pylint: disable=unused-argument
     }]
 
 
+@pytest.mark.appmap_enabled
+def test_app_can_read_body(client, events):  # pylint: disable=unused-argument
+    response = client.post('/echo', json={'test': 'json'})
+    assert response.content == b'{"test": "json"}'
+
+
 # pylint: disable=arguments-differ
 class ClientAdaptor(django.test.Client):
     """Adaptor for the client request parameters used in .web_framework tests."""
@@ -90,13 +96,17 @@ def post_unnamed_view(_request, arg):
 def user_post_view(_request, username, post_id):
     return django.http.HttpResponse(f'post {username} {post_id}')
 
+def echo_view(request):
+    return django.http.HttpResponse(request.body)
+
 urlpatterns = [
     django.urls.path('test', view),
     django.urls.path('', view),
     django.urls.re_path('^user/(?P<username>[^/]+)$', user_view),
     django.urls.path('post/<int:post_id>', post_view),
     django.urls.path('post/<username>/<int:post_id>/summary', user_post_view),
-    django.urls.re_path(r'^post/unnamed/(\d+)$', post_unnamed_view)
+    django.urls.re_path(r'^post/unnamed/(\d+)$', post_unnamed_view),
+    django.urls.path('echo', echo_view),
 ]
 
 def test_unnamed(client, events):


### PR DESCRIPTION
Fixes a problem with Django JSON parameter capture preventing the application from accessing the request body, causing the error:

    django.http.request.RawPostDataException: You cannot access body after reading from request's data stream