### PR TITLE
Fix params corner cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - When an argument to a method is missing, don't raise an exception in the
   appmap code. Instead omit the missing parameter and allow the original
   function call to raise ArgumentError if appropriate.
+- Handle the case when a method is called with self=None.
 
 ## [1.0.0] - 2021-05-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [#55] Informative message is displayed when appmap.yml is missing.
 
+### Fixed
+- When an argument to a method is missing, don't raise an exception in the
+  appmap code. Instead omit the missing parameter and allow the original
+  function call to raise ArgumentError if appropriate.
+
 ## [1.0.0] - 2021-05-27
 ### Added
 - [#105] django integration now captures `normalized_path_info` for `http_server_request`

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -194,10 +194,16 @@ class CallEvent(Event):
                 if p.name in kwargs:
                     value = kwargs[p.name]
                 else:
-                    value = args[0]
-                    args = args[1:]
+                    if args:
+                        value = args[0]
+                        args = args[1:]
+                    else:
+                        continue  # required argument missing
             elif p.kind == 'keyreq':
-                value = kwargs[p.name]
+                if p.name in kwargs:
+                    value = kwargs[p.name]
+                else:
+                    continue  # required argument missing
             elif p.kind == 'opt' or p.kind == 'key':
                 value = kwargs.get(p.name, p.default)
             elif p.kind == 'rest':

--- a/appmap/test/test_params.py
+++ b/appmap/test/test_params.py
@@ -1,3 +1,7 @@
+"""Tests for the function parameter handling"""
+
+# pylint: disable=missing-function-docstring
+
 import inspect
 import sys
 
@@ -152,6 +156,12 @@ class TestInstanceMethods(TestMethodBase):
             'kind': 'req',
             'value': expected_value
         })
+
+    @staticmethod
+    @pytest.mark.parametrize('params', ['one'], indirect=True)
+    def test_one_arg_missing(params):
+        evt = params.C().one()
+        assert len(evt.parameters) == 0
 
     @pytest.mark.parametrize('params,arg,expected',
                              [('one', 'world', ('builtins.str', "'world'")),

--- a/appmap/test/test_params.py
+++ b/appmap/test/test_params.py
@@ -163,6 +163,26 @@ class TestInstanceMethods(TestMethodBase):
         evt = params.C().one()
         assert len(evt.parameters) == 0
 
+    @pytest.mark.parametrize('params', ['one'], indirect=True)
+    def test_one_receiver_none(self, params):
+        evt = params.C.one(None, 1)
+        assert len(evt.parameters) == 1
+
+        assert evt.receiver == {
+            'name': 'self',
+            'kind': 'req',
+            'class': 'builtins.NoneType',
+            'object_id': evt.receiver['object_id'],
+            'value': 'None'
+        }
+
+        self.assert_parameter(evt, 0, {
+            'name': 'p',
+            'class': 'builtins.int',
+            'kind': 'req',
+            'value': '1'
+        })
+
     @pytest.mark.parametrize('params,arg,expected',
                              [('one', 'world', ('builtins.str', "'world'")),
                               ('one', None, ('builtins.NoneType', 'None'))],


### PR DESCRIPTION
Fixes handling of parameters in two corner cases:
- missing required argument,
- method called with self=None.

The latter caused an error when I was trying to map saleor ([`saleor/graphql/page/tests/test_page_types_sorting_and_filtering.py::test_sort_page_types_by_slug`](https://github.com/mirumee/saleor/blob/master/saleor/graphql/page/tests/test_page_types_sorting_and_filtering.py#L70), for reference).