### PR TITLE
Follow wrappers when reflecting for function signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appmap code. Instead omit the missing parameter and allow the original
   function call to raise ArgumentError if appropriate.
 - Handle the case when a method is called with self=None.
+- Function signature reflection now follows wrappers. This allows eg. functions
+  decorated with functools.lru_cache to have their parameters captured.
 
 ### Changed
 - Update tox config to test Django 2.2

--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -158,9 +158,9 @@ class CallEvent(Event):
         try:
             fn = filterable.obj
             if filterable.fntype != FnType.CLASS:
-                sig = inspect.signature(fn, follow_wrapped=False)
+                sig = inspect.signature(fn, follow_wrapped=True)
             else:
-                sig = inspect.signature(filterable.static_fn.__func__, follow_wrapped=False)
+                sig = inspect.signature(filterable.static_fn.__func__, follow_wrapped=True)
         except ValueError:
             # Can't get signatures built-ins
             return []

--- a/appmap/test/data/example_class.py
+++ b/appmap/test/data/example_class.py
@@ -1,4 +1,9 @@
-from functools import wraps
+"""A class using all the slightly different ways a function could be defined
+and called. Used for testing appmap instrumentation.
+"""
+# pylint: disable=missing-function-docstring
+
+from functools import lru_cache, wraps
 import time
 
 
@@ -64,6 +69,11 @@ class ExampleClass(Super, ClassMethodMixin):
     @wrap_fn
     def wrapped_instance_method(self):
         return 'wrapped_instance_method'
+
+    @staticmethod
+    @lru_cache(maxsize=1)
+    def static_cached(value):
+        return value + 1
 
     def instance_with_param(self, p):
         return p

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -14,7 +14,6 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "static_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 71,
       "static": true,
       "parameters": [],
       "id": 2,
@@ -35,7 +34,6 @@
       "defined_class": "example_class.ClassMethodMixin",
       "method_id": "class_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 9,
       "static": true,
       "receiver": {
         "name": "cls",
@@ -62,7 +60,6 @@
       "defined_class": "example_class.Super",
       "method_id": "instance_method",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 15,
       "static": false,
       "receiver": {
         "name": "self",
@@ -89,7 +86,6 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "test_exception",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 45,
       "static": false,
       "receiver": {
         "name": "self",
@@ -118,7 +114,6 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "call_yaml",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 76,
       "static": true,
       "parameters": [],
       "id": 10,
@@ -129,7 +124,6 @@
       "defined_class": "example_class.ExampleClass",
       "method_id": "dump_yaml",
       "path": "appmap/test/data/example_class.py",
-      "lineno": 80,
       "static": true,
       "parameters": [
         {
@@ -147,7 +141,6 @@
       "defined_class": "yaml",
       "method_id": "dump",
       "path": "yaml/__init__.py",
-      "lineno": 285,
       "static": true,
       "parameters": [
         {
@@ -193,7 +186,6 @@
       "defined_class": "yaml",
       "method_id": "dump",
       "path": "yaml/__init__.py",
-      "lineno": 285,
       "static": true,
       "parameters": [
         {
@@ -268,7 +260,7 @@
             {
               "name": "class_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:9",
+              "location": "appmap/test/data/example_class.py",
               "static": true
             }
           ]
@@ -280,25 +272,25 @@
             {
               "name": "call_yaml",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:76",
+              "location": "appmap/test/data/example_class.py",
               "static": true
             },
             {
               "name": "dump_yaml",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:80",
+              "location": "appmap/test/data/example_class.py",
               "static": true
             },
             {
               "name": "static_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:71",
+              "location": "appmap/test/data/example_class.py",
               "static": true
             },
             {
               "name": "test_exception",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:45",
+              "location": "appmap/test/data/example_class.py",
               "static": false
             }
           ]
@@ -310,7 +302,7 @@
             {
               "name": "instance_method",
               "type": "function",
-              "location": "appmap/test/data/example_class.py:15",
+              "location": "appmap/test/data/example_class.py",
               "static": false
             }
           ]
@@ -325,7 +317,7 @@
           "name": "dump",
           "type": "function",
           "comment": "function comment",
-          "location": "yaml/__init__.py:285",
+          "location": "yaml/__init__.py",
           "static": true
         }
       ]

--- a/appmap/test/normalize.py
+++ b/appmap/test/normalize.py
@@ -1,6 +1,7 @@
 from operator import itemgetter
 import platform
 import re
+from typing import List
 
 import json
 import pytest
@@ -104,3 +105,22 @@ def normalize_appmap(generated_appmap):
         return dct
 
     return json.loads(generated_appmap, object_hook=normalize)
+
+
+def remove_line_numbers(appmap: dict):
+    """Remove all line numbers from an appmap (in place).
+    Makes the tests easier to modify.
+    """
+
+    def do_classmap(classmap: List[dict]):
+        location_re = re.compile(r':\d+$')
+        for entry in classmap:
+            if 'location' in entry:
+                entry['location'] = location_re.sub('', entry['location'])
+            do_classmap(entry.get('children', []))
+
+    do_classmap(appmap['classMap'])
+    for event in appmap['events']:
+        assert isinstance(event.pop('lineno', 42), int)
+
+    return appmap

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -1,3 +1,6 @@
+"""Test recording functions called and defined in various ways."""
+# pylint: disable=missing-function-docstring
+
 import json
 import os
 import sys
@@ -105,3 +108,15 @@ def test_exec_module_protection(monkeypatch):
 
     f()
     assert True
+
+
+@pytest.mark.appmap_enabled
+@pytest.mark.usefixtures('with_data_dir')
+def test_static_cached(events):
+    from example_class import ExampleClass  # pylint: disable=import-outside-toplevel
+    ExampleClass.static_cached(42)
+    assert events[0].parameters[0].items() >= {
+        'name': 'value',
+        'class': 'builtins.int',
+        'value': '42'
+    }.items()

--- a/appmap/test/test_recording.py
+++ b/appmap/test/test_recording.py
@@ -7,7 +7,7 @@ import pytest
 import appmap
 
 from appmap._implementation.recording import Recorder, wrap_exec_module
-from .normalize import normalize_appmap
+from .normalize import normalize_appmap, remove_line_numbers
 
 
 @pytest.mark.appmap_enabled
@@ -31,7 +31,7 @@ class TestRecordingWhenEnabled:
             ExampleClass.call_yaml()
 
         generated_appmap = normalize_appmap(appmap.generation.dump(r))
-        assert generated_appmap == expected_appmap
+        assert remove_line_numbers(generated_appmap) == expected_appmap
 
     def test_recording_clears(self):
         from example_class import ExampleClass  # pylint: disable=import-error


### PR DESCRIPTION
This fixes the problem mentioned in #124 and #80 (functions decorated with lru_cache not having their arguments captured) without actually doing #124. @apotterri, do you remember if there was a specific reason to not follow wrappers? Tests seem to pass fine, I've also ran saleor test suite and everything looks in order.