### PR TITLE
update error message for missing config file to show full path

### DIFF
--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -26,7 +26,7 @@ def warn_config_missing(path):
     name = path.resolve().parent.name
     package = re.sub(r'\W', '.', name).lower()
     logger.warning(dedent(f'''
-        Config file "{path}" is missing; AppMaps won't be recorded.
+        Config file "{path.absolute()}" is missing; AppMaps won't be recorded.
         You need to create the file, for example:
 
         name: {name}  # your project name


### PR DESCRIPTION
Changed "warn_config_missing" error so the absolute path of the missing config file is printed.