### PR TITLE
Use full path for default appmap.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [#128] The error message for a missing config file now shows the full path where the
+  file was expected to be found.
+
 ## [1.1.0] - 2021-06-08
 ### Added
 - [#55] Informative message is displayed when appmap.yml is missing.

--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -75,7 +75,7 @@ class Config:
     @property
     @lru_cache(maxsize=None)
     def _config(self):
-        path = Path(Env.current.get("APPMAP_CONFIG", "appmap.yml"))
+        path = Path(Env.current.get("APPMAP_CONFIG", "appmap.yml")).resolve()
         if path.is_file():
             ret = yaml.safe_load(path.read_text())
             logger.info('config: %s', ret)

--- a/appmap/test/test_configuration.py
+++ b/appmap/test/test_configuration.py
@@ -1,6 +1,7 @@
 """Test Configuration"""
 # pylint: disable=missing-function-docstring
 
+from pathlib import Path
 import pytest
 
 import appmap
@@ -34,7 +35,8 @@ def test_config_not_found(caplog):
     })
     assert Config().name is None
     assert not appmap.enabled()
-    assert '"notfound.yml" is missing' in caplog.text
+    not_found = Path('notfound.yml').resolve()
+    assert f'"{not_found}" is missing' in caplog.text
 
 
 cf = lambda: ConfigFilter(NullFilter())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ python = "^3.6"
 PyYAML = "~5.3.0"
 inflection = "~0.3.0"
 importlib-metadata = ">=0.8"
+Django = { version = "^3.1.6", python = "^3.6", optional = true }
 
 [tool.poetry.dev-dependencies]
 httpretty = "^1.0.5"
@@ -48,7 +49,6 @@ pyfakefs = "^4.3.2"
 pprintpp = "^0.4.0"
 coverage = "^5.3"
 pytest-mock = "^3.5.1"
-Django = { version = "^3.1.6", python = "^3.6", optional = true }
 flask = "^1.1.2"
 SQLAlchemy = { version = "^1.4.11", python = "^3.6"}
 tox = "^3.22.0"


### PR DESCRIPTION
Resolve the path to `appmap.yml` to an absolute path. This allows the error message for a missing config file to show the expected location of the file.

Fixes #131 .