### PR TITLE
Make django path normalization more robust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extensions.
 
 ### Fixed
+- [#138] Path normalization for django requests is now more robust.
 - [#128] The error message for a missing config file now shows the full path where the
   file was expected to be found.
 


### PR DESCRIPTION
Make path normalization more robust. Instead of trying to duplicate the
functionality of resolve(), we'll call it and interpret the route it
returns.

Fixes #138.
