### PR TITLE
fix: Loosen version for some dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ packages = [
 # https://github.com/applandinc/applandinc.github.io/blob/master/_docs/reference/appmap-python.md#supported-versions
 python = "^3.6"
 PyYAML = "^5.3.0"
-inflection = "^0.3.0"
+inflection = ">=0.3.0"
 importlib-metadata = ">=0.8"
 Django = { version = "^3.1.6", python = "^3.6", optional = true }
 
@@ -45,14 +45,14 @@ pytest-randomly = "^3.5.0"
 pylint = "^2.6.0"
 flake8 = "^3.8.4"
 pyfakefs = "^4.3.2"
-pprintpp = "^0.4.0"
+pprintpp = ">=0.4.0"
 coverage = "^5.3"
 pytest-mock = "^3.5.1"
 flask = "^1.1.2"
 SQLAlchemy = { version = "^1.4.11", python = "^3.6"}
 tox = "^3.22.0"
 tox-pyenv = "^1.1.0"
-tox-travis = "^0.12"
+tox-travis = ">=0.12"
 Twisted = "^21.2.0"
 requests = "^2.25.1"
 pytest-django = "^4.4.0"


### PR DESCRIPTION
Loosen the version specification for a couple of dependencies. Caret
dependencies in pyproject.toml that start with a zero behave differently
than those that start with a non-zero number (see the poetry doc for
details).

In particular, the specification for inflection is too restrictive:
"^0.3.0" will only update to "<0.4.0", and "0.5.1" has been released.