### PR TITLE
fix: Honor APPMAP env var when config is present

### DIFF
--- a/appmap/_implementation/configuration.py
+++ b/appmap/_implementation/configuration.py
@@ -178,12 +178,13 @@ class Config:
         if path.is_file():
             self.file_present = True
 
+            should_enable = Env.current.enabled
             Env.current.enabled = False
             self.file_valid = False
             try:
                 self._config = yaml.safe_load(path.read_text())
                 self.file_valid = True
-                Env.current.enabled = True
+                Env.current.enabled = should_enable
             except ParserError:
                 pass
             logger.info('config: %s', self._config)

--- a/appmap/test/conftest.py
+++ b/appmap/test/conftest.py
@@ -38,7 +38,10 @@ def pytest_runtest_setup(item):
         d = _data_dir(item.config)
         config = d / appmap_yml
         Env.current.set('APPMAP_CONFIG', config)
-        env = {'APPMAP': 'true', 'APPMAP_CONFIG': config}
+        appmap_enabled = mark.kwargs.get('appmap_enabled', 'true')
+        env = {'APPMAP_CONFIG': config}
+        if isinstance(appmap_enabled, str):
+            env['APPMAP'] = appmap_enabled
 
     appmap._implementation.initialize(env=env)  # pylint: disable=protected-access
 

--- a/appmap/test/test_configuration.py
+++ b/appmap/test/test_configuration.py
@@ -56,6 +56,14 @@ def test_is_disabled_when_false():
     assert not appmap.enabled()
 
 
+@pytest.mark.appmap_enabled(appmap_enabled=None)
+def test_is_disabled_with_valid_config():
+    c = Config()
+    assert c.file_present
+    assert c.file_valid
+
+    assert not appmap.enabled()
+
 def test_config_not_found(caplog):
     appmap._implementation.initialize(env={  # pylint: disable=protected-access
         'APPMAP': 'true', 'APPMAP_CONFIG': 'notfound.yml'


### PR DESCRIPTION
Make sure to honor the setting (or lack thereof) of the `APPMAP`environment variable when a config file is present. Previously, the simple presence of a valid config file caused recording to be enabled.