### PR TITLE
Allow specifying function labels in the config file

### DIFF
--- a/appmap/_implementation/event.py
+++ b/appmap/_implementation/event.py
@@ -279,6 +279,8 @@ class CallEvent(Event):
 
     def to_dict(self, attrs=None):
         ret = super().to_dict() # get the attrs defined in __slots__
+        if 'labels' in ret:
+            del ret['labels']  # labels should only appear in the classmap
 
         # update with the computed properties
         ret.update(super().to_dict(attrs=['defined_class', 'method_id',

--- a/appmap/_implementation/recording.py
+++ b/appmap/_implementation/recording.py
@@ -90,7 +90,7 @@ class FilterableFn(
     __slots__ = ()
 
     def __new__(c, scope, fn, static_fn):
-        fqname = '%s.%s' % (scope.fqname, fn.__qualname__)
+        fqname = '%s.%s' % (scope.fqname, fn.__name__)
         self = super(FilterableFn, c).__new__(c, fqname, fn, scope, static_fn)
         return self
 

--- a/appmap/test/data/appmap.yml
+++ b/appmap/test/data/appmap.yml
@@ -6,3 +6,6 @@ packages:
 - path: example_class
 - path: package1
 - dist: PyYAML
+labels:
+  yaml.dump: serialization
+  example_class.ExampleClass.test_exception: [two, labels]

--- a/appmap/test/data/expected.appmap.json
+++ b/appmap/test/data/expected.appmap.json
@@ -291,7 +291,8 @@
               "name": "test_exception",
               "type": "function",
               "location": "appmap/test/data/example_class.py",
-              "static": false
+              "static": false,
+              "labels": ["two", "labels"]
             }
           ]
         },
@@ -318,7 +319,8 @@
           "type": "function",
           "comment": "function comment",
           "location": "yaml/__init__.py",
-          "static": true
+          "static": true,
+          "labels": ["serialization"]
         }
       ]
     }


### PR DESCRIPTION
This change is especially useful for library functions; it's not intended to replace the @labels decorator but instead allow to configure labeling of code outside of the developer control.

Planned followups:
- doc change on the website,
- predefined labels for popular libraries.
