### PR TITLE
fix: Handle a partial finder function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 - tox
 - poetry build
 - echo "$DOCKERHUB_PASSWORD" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-- ci/test_install.sh
+- ci/run_tests.sh
 
 before_deploy:
 - |

--- a/appmap/_implementation/recording.py
+++ b/appmap/_implementation/recording.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 from collections.abc import MutableSequence
 
+import functools
 import inspect
 import logging
 import sys
@@ -286,7 +287,8 @@ class Recorder:
 
 def wrap_finder_function(fn, decorator):
     ret = fn
-    marker = '_appmap_wrapped_%s' % fn.__name__
+    fn_name = fn.func.__name__ if isinstance(fn, functools.partial) else fn.__name__
+    marker = '_appmap_wrapped_%s' % fn_name
 
     # Figure out which object should get the marker attribute. If fn
     # is a bound function, put it on the object it's bound to,

--- a/appmap/test/data/unittest/expected/pytest.appmap.json
+++ b/appmap/test/data/unittest/expected/pytest.appmap.json
@@ -12,7 +12,7 @@
     "recording": {
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
-      "source_location": "simple/test_simple.py:9"
+      "source_location": "simple/test_simple.py:13"
     },
     "name": "Unit test test hello world",
     "feature": "Hello world",
@@ -27,7 +27,7 @@
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
       "path": "simple/test_simple.py",
-      "lineno": 10,
+      "lineno": 14,
       "static": false,
       "receiver": {
         "name": "self",
@@ -177,7 +177,7 @@
                 {
                   "name": "test_hello_world",
                   "type": "function",
-                  "location": "simple/test_simple.py:10",
+                  "location": "simple/test_simple.py:14",
                   "static": false
                 }
               ]

--- a/appmap/test/data/unittest/expected/unittest.appmap.json
+++ b/appmap/test/data/unittest/expected/unittest.appmap.json
@@ -12,7 +12,7 @@
     "recording": {
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
-      "source_location": "simple/test_simple.py:10"
+      "source_location": "simple/test_simple.py:14"
     },
     "name": "Unit test test hello world",
     "feature": "Hello world",
@@ -27,7 +27,7 @@
       "defined_class": "simple.test_simple.UnitTestTest",
       "method_id": "test_hello_world",
       "path": "simple/test_simple.py",
-      "lineno": 10,
+      "lineno": 14,
       "static": false,
       "receiver": {
         "name": "self",
@@ -177,7 +177,7 @@
                 {
                   "name": "test_hello_world",
                   "type": "function",
-                  "location": "simple/test_simple.py:10",
+                  "location": "simple/test_simple.py:14",
                   "static": false
                 }
               ]

--- a/appmap/test/data/unittest/simple/test_simple.py
+++ b/appmap/test/data/unittest/simple/test_simple.py
@@ -1,6 +1,10 @@
 import unittest
 from unittest.mock import patch
 
+# Importing from decouple will cause a failure if we're not hooking
+# finders correctly.
+from decouple import config
+
 import appmap.unittest
 
 import simple

--- a/appmap/test/test_test_frameworks.py
+++ b/appmap/test/test_test_frameworks.py
@@ -26,6 +26,14 @@ def test_appmap_unittest_runner(testdir):
     verify_expected_appmap(testdir)
     verify_expected_metadata(testdir)
 
+def test_appmap_unittest_runner_disabled(testdir, monkeypatch):
+    monkeypatch.delenv('APPMAP', raising=False)
+
+    result = testdir.run(sys.executable, '-m', 'appmap.unittest', '-vv',
+                         'simple.test_simple.UnitTestTest.test_hello_world')
+    assert result.ret == 0
+    r = re.compile(r'AppMap disabled')
+    assert [l for l in filter(r.search, result.errlines)], "Warning not found"
 
 def test_pytest_runner_unittests(testdir):
     testdir.test_type = 'pytest'

--- a/appmap/unittest.py
+++ b/appmap/unittest.py
@@ -1,43 +1,56 @@
 from contextlib import contextmanager
+import logging
 import unittest
 
+import appmap
 from appmap._implementation import testing_framework
 import appmap.wrapt as wrapt
 
 
-session = testing_framework.session('unittest')
+logger = logging.getLogger(__name__)
 
-def get_test_location(cls, method_name):
-    from appmap._implementation.utils import get_function_location
-    fn = getattr(cls, method_name)
-    return get_function_location(fn)
-
-
-# unittest.case._Outcome.testPartExecutor is used by all supported
-# versions of unittest to run test cases. `isTest` will be True when
-# the part is the actual test method, False when it's setUp or
-# teardown.
-@wrapt.patch_function_wrapper('unittest.case', '_Outcome.testPartExecutor')
-@contextmanager
-def testPartExecutor(wrapped, _, args, kwargs):
-    def _args(test_case, *_, isTest=False, **__):
-        return (test_case, isTest)
-    test_case, is_test = _args(*args, **kwargs)
-    already_recording = getattr(test_case, '_appmap_pytest_recording', None)
-    if (not is_test) or already_recording:
-        with wrapped(*args, **kwargs):
-            yield
+def setup_unittest():
+    if not appmap.enabled():
+        # Using this runner without enabling AppMap might not be what
+        # the user intended, so issue a warning.
+        logger.warning("AppMap disabled. Did you forget to set APPMAP=true?")
         return
 
-    method_name = test_case.id().split('.')[-1]
-    location = get_test_location(test_case.__class__, method_name)
-    with session.record(
-            test_case.__class__,
-            method_name,
-            location=location) as metadata:
-        with wrapped(*args, **kwargs), testing_framework.collect_result_metadata(metadata):
-            yield
+    session = testing_framework.session('unittest')
 
+    def get_test_location(cls, method_name):
+        from appmap._implementation.utils import get_function_location
+        fn = getattr(cls, method_name)
+        return get_function_location(fn)
+
+
+    # unittest.case._Outcome.testPartExecutor is used by all supported
+    # versions of unittest to run test cases. `isTest` will be True when
+    # the part is the actual test method, False when it's setUp or
+    # teardown.
+    @wrapt.patch_function_wrapper('unittest.case', '_Outcome.testPartExecutor')
+    @contextmanager
+    def testPartExecutor(wrapped, _, args, kwargs):
+        def _args(test_case, *_, isTest=False, **__):
+            return (test_case, isTest)
+        test_case, is_test = _args(*args, **kwargs)
+        already_recording = getattr(test_case, '_appmap_pytest_recording', None)
+        if (not is_test) or already_recording:
+            with wrapped(*args, **kwargs):
+                yield
+            return
+
+        method_name = test_case.id().split('.')[-1]
+        location = get_test_location(test_case.__class__, method_name)
+        with session.record(
+                test_case.__class__,
+                method_name,
+                location=location) as metadata:
+            with wrapped(*args, **kwargs), testing_framework.collect_result_metadata(metadata):
+                yield
+
+
+setup_unittest()
 
 if __name__ == '__main__':
     unittest.main(module=None)

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -4,6 +4,5 @@ set -x
 docker run -i --rm\
   -v $PWD/dist:/dist -v $PWD/appmap/test/data/unittest:/appmap/test/data/unittest\
   -v $PWD/ci:/ci\
-  --entrypoint /bin/bash\
   -w /tmp\
-  python:3.9 /ci/smoketest.sh
+  python:3.9 bash -ce '/ci/smoketest.sh; /ci/test_pipenv.sh'

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-pip install -U pip pytest flask
+pip install -U pip pytest flask python-decouple
 pip install /dist/appmap-*-py3-none-any.whl
 
 cp -R /appmap/test/data/unittest/simple ./.

--- a/ci/test_pipenv.sh
+++ b/ci/test_pipenv.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -e
+pip install pipenv
+
+mkdir /pipenv || true
+cd /pipenv
+
+pipenv run /ci/smoketest.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ inflection = ">=0.3.0"
 importlib-metadata = ">=0.8"
 Django = { version = "^3.1.6", python = "^3.6", optional = true }
 importlib-resources = "^5.4.0"
+packaging = "^21.3"
 
 [tool.poetry.dev-dependencies]
 httpretty = "^1.0.5"
@@ -57,6 +58,7 @@ tox-travis = ">=0.12"
 Twisted = "^21.2.0"
 requests = "^2.25.1"
 pytest-django = "^4.4.0"
+python-decouple = "^3.5"
 
 [tool.poetry.extras]
 test = ["Django"]


### PR DESCRIPTION
If a finder function doesn't have a `__name__` attr, and it's a
`functools.partial`, use its `func.__name__` instead.