### PR TITLE
fix: Avoid querying database version when executing client queries

### DIFF
--- a/appmap/django.py
+++ b/appmap/django.py
@@ -117,6 +117,11 @@ CursorDebugWrapper.execute = wrapped_execute
 @receiver(connection_created)
 def connected(sender, connection, **_):
     # pylint: disable=unused-argument
+
+    # warm the version cache in the backend to avoid running
+    # additional queries in the middle of processing client queries
+    database_version(connection)
+
     wrappers = connection.execute_wrappers
     if not any(isinstance(x, ExecuteWrapper) for x in wrappers):
         wrappers.append(ExecuteWrapper())

--- a/ci/smoketest.sh
+++ b/ci/smoketest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
-pip install -U pip pytest flask python-decouple
+pip install -U pip pytest "flask<2" python-decouple
 pip install /dist/appmap-*-py3-none-any.whl
 
 cp -R /appmap/test/data/unittest/simple ./.


### PR DESCRIPTION
While I couldn't reproduce it, a user has reported seeing a stack
overflow while processing an SQL query with MySQL and django. It
seems to have been caused by appmap querying for the server version,
which entails another SQL query against the server with MySQL.

Since MySQL backend caches that information, querying it when first
establishing the connection ensures the additional query is avoided
later at runtime, thus avoiding this problem.

Fixes #158