### PR TITLE
fix: handle a tuple value for settings.MIDDLEWARE

### DIFF
--- a/appmap/test/data/django/test/test_app.py
+++ b/appmap/test/data/django/test/test_app.py
@@ -1,13 +1,19 @@
 import app
+import pytest
 from django.core.handlers.base import BaseHandler
 from django.test import Client
 
 
-def test_middleware(rf, settings):
-    settings.MIDDLEWARE = ["app.middleware.hello_world"]
-    request = rf.get("/")
+@pytest.mark.parametrize(
+    "mware", [["app.middleware.hello_world"], ("app.middleware.hello_world",)]
+)
+def test_middleware(rf, settings, mware):
+    settings.MIDDLEWARE = mware
+    orig_type = type(settings.MIDDLEWARE)
+    request = rf.get("/_appmap/record")
     handler = BaseHandler()
     handler.load_middleware()
+    assert type(settings.MIDDLEWARE) == orig_type
     response = handler.get_response(request)
     assert response.status_code == 200
 

--- a/appmap/test/test_django.py
+++ b/appmap/test/test_django.py
@@ -191,7 +191,8 @@ def test_middleware_reset(pytester, monkeypatch):
 
     # To really check middleware reset, the tests must run in order,
     # so disable randomly.
-    pytester.runpytest("-svv", "-p", "no:randomly")
+    result = pytester.runpytest("-svv", "-p", "no:randomly")
+    result.assert_outcomes(passed=3, failed=0, errors=0)
 
     # Look for the http_server_request event in test_app's appmap. If
     # middleware reset is broken, it won't be there.


### PR DESCRIPTION
Django is fine with settings.MIDDLEWARE being either a tuple or a list, but we were expecting a list. Now, we can handle either.

Fixes getappmap/board#225.