### PR TITLE
fix: Use raw string values instead of repr() for str types in display_string

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# appmap-python
+
+Python agent for AppMap. Records function calls, HTTP requests, SQL queries, parameters, return values, and exceptions into `.appmap.json` files.
+
+## Running tests
+
+Tests must be run via `tox` or the `appmap-python` wrapper, not bare `pytest`. The wrapper sets `APPMAP=true`, which is required for conditional imports in `appmap/__init__.py` (e.g. `generation`). Subprocess-based tests also need the `appmap-python` script in PATH.
+
+```sh
+# Correct - via tox (how CI runs them)
+tox
+
+# Correct - via appmap-python wrapper
+appmap-python pytest
+
+# Also works for quick local iteration on non-subprocess tests
+APPMAP=true .venv/bin/python -m pytest _appmap/test/test_events.py
+
+# WRONG - will fail on subprocess tests
+pytest
+```
+
+## Project structure
+
+- `appmap/` - Public package entry point (conditional imports based on APPMAP env var)
+- `_appmap/` - Internal implementation (event recording, instrumentation, web framework integration)
+- `_appmap/test/` - Test suite
+- `_appmap/test/data/` - Test fixtures and expected appmap JSON files

--- a/_appmap/event.py
+++ b/_appmap/event.py
@@ -47,13 +47,14 @@ class _EventIds:
 
 def display_string(val, display_value=False):
     # If we're asked to display parameters, make a best-effort attempt
-    # to get a string value for the parameter using repr(). If parameter
-    # display is disabled, or repr() has raised, just formulate a value
-    # from the class and id.
+    # to get a string value for the parameter. str types are returned as-is;
+    # other types use repr(). If parameter display is disabled, or repr() has
+    # raised, just formulate a value from the class and id.
     value = None
     if display_value:
         try:
-            value = repr(val)
+            # Use issubclass(type()) instead of isinstance() to avoid side effects on lazy objects
+            value = val if issubclass(type(val), str) else repr(val)
         except Exception:  # pylint: disable=broad-except
             pass
 

--- a/_appmap/test/data/expected.appmap.json
+++ b/_appmap/test/data/expected.appmap.json
@@ -23,7 +23,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'ExampleClass.static_method\\n...\\n'"
+        "value": "ExampleClass.static_method\n...\n"
       },
       "parent_id": 1,
       "id": 2,
@@ -49,7 +49,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'ClassMethodMixin#class_method, cls ExampleClass'"
+        "value": "ClassMethodMixin#class_method, cls ExampleClass"
       },
       "parent_id": 3,
       "id": 4,
@@ -75,7 +75,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Super#instance_method'"
+        "value": "Super#instance_method"
       },
       "parent_id": 5,
       "id": 6,
@@ -127,7 +127,7 @@
           "name": "data",
           "kind": "req",
           "class": "builtins.str",
-          "value": "'ExampleClass.call_yaml'"
+          "value": "ExampleClass.call_yaml"
         }
       ],
       "id": 10,
@@ -144,7 +144,7 @@
           "name": "data",
           "kind": "req",
           "class": "builtins.str",
-          "value": "'ExampleClass.call_yaml'"
+          "value": "ExampleClass.call_yaml"
         },
         {
           "name": "stream",
@@ -176,7 +176,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'ExampleClass.call_yaml\\n...\\n'"
+        "value": "ExampleClass.call_yaml\n...\n"
       },
       "parent_id": 11,
       "id": 12,
@@ -190,7 +190,7 @@
           "name": "data",
           "kind": "req",
           "class": "builtins.str",
-          "value": "'ExampleClass.call_yaml'"
+          "value": "ExampleClass.call_yaml"
         },
         {
           "name": "stream",
@@ -222,7 +222,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'ExampleClass.call_yaml\\n...\\n'"
+        "value": "ExampleClass.call_yaml\n...\n"
       },
       "parent_id": 13,
       "id": 14,

--- a/_appmap/test/data/pytest/expected/pytest-numpy1-no-test-cases.appmap.json
+++ b/_appmap/test/data/pytest/expected/pytest-numpy1-no-test-cases.appmap.json
@@ -56,7 +56,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello'"
+        "value": "Hello"
       },
       "parent_id": 2,
       "id": 3,
@@ -83,7 +83,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'world!'"
+        "value": "world!"
       },
       "parent_id": 4,
       "id": 5,
@@ -93,7 +93,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello world!'"
+        "value": "Hello world!"
       },
       "parent_id": 1,
       "id": 6,

--- a/_appmap/test/data/pytest/expected/pytest-numpy1.appmap.json
+++ b/_appmap/test/data/pytest/expected/pytest-numpy1.appmap.json
@@ -66,7 +66,7 @@
     },
     {
       "return_value": {
-        "value": "'Hello'",
+        "value": "Hello",
         "class": "builtins.str"
       },
       "parent_id": 3,
@@ -93,7 +93,7 @@
     },
     {
       "return_value": {
-        "value": "'world!'",
+        "value": "world!",
         "class": "builtins.str"
       },
       "parent_id": 5,
@@ -103,7 +103,7 @@
     },
     {
       "return_value": {
-        "value": "'Hello world!'",
+        "value": "Hello world!",
         "class": "builtins.str"
       },
       "parent_id": 2,

--- a/_appmap/test/data/pytest/expected/pytest-numpy2-no-test-cases.appmap.json
+++ b/_appmap/test/data/pytest/expected/pytest-numpy2-no-test-cases.appmap.json
@@ -56,7 +56,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello'"
+        "value": "Hello"
       },
       "parent_id": 2,
       "id": 3,
@@ -83,7 +83,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'world!'"
+        "value": "world!"
       },
       "parent_id": 4,
       "id": 5,
@@ -93,7 +93,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello world!'"
+        "value": "Hello world!"
       },
       "parent_id": 1,
       "id": 6,

--- a/_appmap/test/data/pytest/expected/pytest-numpy2.appmap.json
+++ b/_appmap/test/data/pytest/expected/pytest-numpy2.appmap.json
@@ -66,7 +66,7 @@
     },
     {
       "return_value": {
-        "value": "'Hello'",
+        "value": "Hello",
         "class": "builtins.str"
       },
       "parent_id": 3,
@@ -93,7 +93,7 @@
     },
     {
       "return_value": {
-        "value": "'world!'",
+        "value": "world!",
         "class": "builtins.str"
       },
       "parent_id": 5,
@@ -103,7 +103,7 @@
     },
     {
       "return_value": {
-        "value": "'Hello world!'",
+        "value": "Hello world!",
         "class": "builtins.str"
       },
       "parent_id": 2,

--- a/_appmap/test/data/unittest/expected/pytest.appmap.json
+++ b/_appmap/test/data/unittest/expected/pytest.appmap.json
@@ -53,12 +53,14 @@
         "class": "simple.Simple",
         "value": "<simple.Simple object at 0xabcdef>"
       },
-      "parameters": [{
-        "class": "builtins.str",
-        "kind": "req",
-        "name": "bang",
-        "value": "'!'"
-      }],
+      "parameters": [
+        {
+          "class": "builtins.str",
+          "kind": "req",
+          "name": "bang",
+          "value": "!"
+        }
+      ],
       "id": 2,
       "event": "call",
       "thread_id": 1
@@ -83,7 +85,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello'"
+        "value": "Hello"
       },
       "parent_id": 3,
       "id": 4,
@@ -110,7 +112,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'world'"
+        "value": "world"
       },
       "parent_id": 5,
       "id": 6,
@@ -120,7 +122,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello world!'"
+        "value": "Hello world!"
       },
       "parent_id": 2,
       "id": 7,

--- a/_appmap/test/data/unittest/expected/unittest-no-test-cases.appmap.json
+++ b/_appmap/test/data/unittest/expected/unittest-no-test-cases.appmap.json
@@ -35,7 +35,7 @@
       "parameters": [
         {
           "kind": "req",
-          "value": "'!'",
+          "value": "!",
           "name": "bang",
           "class": "builtins.str"
         }
@@ -67,7 +67,7 @@
     },
     {
       "return_value": {
-        "value": "'Hello'",
+        "value": "Hello",
         "class": "builtins.str"
       },
       "parent_id": 2,
@@ -94,7 +94,7 @@
     },
     {
       "return_value": {
-        "value": "'world'",
+        "value": "world",
         "class": "builtins.str"
       },
       "parent_id": 4,
@@ -104,7 +104,7 @@
     },
     {
       "return_value": {
-        "value": "'Hello world!'",
+        "value": "Hello world!",
         "class": "builtins.str"
       },
       "parent_id": 1,

--- a/_appmap/test/data/unittest/expected/unittest.appmap.json
+++ b/_appmap/test/data/unittest/expected/unittest.appmap.json
@@ -53,12 +53,14 @@
         "class": "simple.Simple",
         "value": "<simple.Simple object at 0xabcdef>"
       },
-      "parameters": [{
-        "class": "builtins.str",
-        "kind": "req",
-        "name": "bang",
-        "value": "'!'"
-      }],
+      "parameters": [
+        {
+          "class": "builtins.str",
+          "kind": "req",
+          "name": "bang",
+          "value": "!"
+        }
+      ],
       "id": 2,
       "event": "call",
       "thread_id": 1
@@ -83,7 +85,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello'"
+        "value": "Hello"
       },
       "parent_id": 3,
       "id": 4,
@@ -110,7 +112,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'world'"
+        "value": "world"
       },
       "parent_id": 5,
       "id": 6,
@@ -120,7 +122,7 @@
     {
       "return_value": {
         "class": "builtins.str",
-        "value": "'Hello world!'"
+        "value": "Hello world!"
       },
       "parent_id": 2,
       "id": 7,

--- a/_appmap/test/test_events.py
+++ b/_appmap/test/test_events.py
@@ -132,11 +132,11 @@ class TestEvents:
 
         assert result == "hello"
         call_event = r.events[0]
-        # Parameter value should be the repr, not the opaque object string
-        assert call_event.parameters[0]["value"] == "'hello'"
+        # Parameter value should be the raw string, not repr-quoted
+        assert call_event.parameters[0]["value"] == "hello"
         # Return value should also be displayed
         return_event = r.events[1]
-        assert return_event.return_value["value"] == "'hello'"
+        assert return_event.return_value["value"] == "hello"
 
         # Unlabeled method should not have its params displayed, even in the same recording
         call_event_unlabeled = r.events[2]

--- a/_appmap/test/test_http.py
+++ b/_appmap/test/test_http.py
@@ -29,8 +29,8 @@ def test_http_client_capture(mock_requests, events):
     }
     message = request.message
     assert message[0] == DictIncluding({"name": "q", "value": "['one', 'two']"})
-    assert (message[1] == DictIncluding({"name": "q2", "value": "'🦠'"})) or (
-        message[1] == DictIncluding({"name": "q2", "value": "'\\U0001f9a0'"})
+    assert (message[1] == DictIncluding({"name": "q2", "value": "🦠"})) or (
+        message[1] == DictIncluding({"name": "q2", "value": "\\U0001f9a0"})
     )
 
     assert events[3].http_client_response == DictIncluding(

--- a/_appmap/test/test_labels.py
+++ b/_appmap/test/test_labels.py
@@ -1,5 +1,6 @@
 import pytest
 
+import appmap
 from _appmap.wrapt import BoundFunctionWrapper, FunctionWrapper
 
 
@@ -54,6 +55,22 @@ class TestLabels:
             ), "yaml.emit should not be instrumented"
 
         verify_example_appmap(check_labels, "instance_method")
+
+    @pytest.mark.appmap_enabled(config="appmap-no-pyyaml.yml")
+    def test_labeled_function_recorded_without_package(self):
+        """A labeled function is recorded even when its package is not in the config."""
+        import yaml  # pylint: disable=import-outside-toplevel
+
+        rec = appmap.Recording()
+        with rec:
+            yaml.dump({"key": "value"})
+
+        # yaml.dump should appear in the recording events because it's labeled
+        # by the formats preset, even though PyYAML is not in the packages list.
+        call_events = [e for e in rec.events if e.event == "call"]
+        assert any(
+            e.method_id == "dump" and "yaml" in e.defined_class for e in call_events
+        ), f"Expected yaml.dump in recorded events, got: {[e.method_id for e in call_events]}"
 
     def test_function_only_in_mod(self, verify_example_appmap):
         def check_labels(*_):

--- a/_appmap/test/test_params.py
+++ b/_appmap/test/test_params.py
@@ -108,7 +108,7 @@ class TestStaticMethods(TestMethodBase):
             "name": "p",
             "class": "builtins.str",
             "kind": "req",
-            "value": "'static'",
+            "value": "static",
         }
 
 
@@ -131,7 +131,7 @@ class TestClassMethods(TestMethodBase):
         self.assert_parameter(
             evt,
             0,
-            {"name": "p", "class": "builtins.str", "kind": "req", "value": "'cls'"},
+            {"name": "p", "class": "builtins.str", "kind": "req", "value": "cls"},
         )
 
 
@@ -145,7 +145,7 @@ class TestInstanceMethods(TestMethodBase):
     @pytest.mark.parametrize(
         "params,arg,expected",
         [
-            ("one", "world", ("builtins.str", "'world'")),
+            ("one", "world", ("builtins.str", "world")),
             ("one", None, ("builtins.NoneType", "None")),
         ],
         indirect=["params"],
@@ -192,7 +192,7 @@ class TestInstanceMethods(TestMethodBase):
     @pytest.mark.parametrize(
         "params,arg,expected",
         [
-            ("one", "world", ("builtins.str", "'world'")),
+            ("one", "world", ("builtins.str", "world")),
             ("one", None, ("builtins.NoneType", "None")),
         ],
         indirect=["params"],

--- a/_appmap/test/web_framework.py
+++ b/_appmap/test/web_framework.py
@@ -45,7 +45,7 @@ class _TestFormData:
         )
 
         assert events[0].message == [
-            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "'example'"})
+            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "example"})
         ]
 
     @staticmethod
@@ -53,7 +53,7 @@ class _TestFormData:
         client.post("/test", data={"my_param": "example"}, content_type="multipart/form-data")
 
         assert events[0].message == [
-            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "'example'"})
+            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "example"})
         ]
 
 
@@ -119,7 +119,7 @@ class _TestRequestCapture:
 
         assert events[0].message == [
             DictIncluding(
-                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+                {"name": "my_param", "class": "builtins.str", "value": "example"}
             )
         ]
         assert events[0].http_server_request == DictIncluding(
@@ -142,7 +142,7 @@ class _TestRequestCapture:
 
         assert events[0].message == [
             DictIncluding(
-                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+                {"name": "my_param", "class": "builtins.str", "value": "example"}
             )
         ]
 
@@ -166,7 +166,7 @@ class _TestRequestCapture:
 
         assert events[0].message == [
             DictIncluding(
-                {"name": "my_param", "class": "builtins.str", "value": "'example'"}
+                {"name": "my_param", "class": "builtins.str", "value": "example"}
             )
         ]
 
@@ -205,7 +205,7 @@ class _TestRequestCapture:
 
         assert events[0].message == [
             DictIncluding(
-                {"name": "username", "class": "builtins.str", "value": "'alice'"}
+                {"name": "username", "class": "builtins.str", "value": "alice"}
             ),
             DictIncluding({"name": "post_id", "class": "builtins.int", "value": "42"}),
         ]
@@ -222,7 +222,7 @@ class _TestFormCapture:
         )
 
         assert events[0].message == [
-            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "'example'"})
+            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "example"})
         ]
 
     @staticmethod
@@ -230,7 +230,7 @@ class _TestFormCapture:
         client.post("/test", data={"my_param": "example"}, content_type="multipart/form-data")
 
         assert events[0].message == [
-            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "'example'"})
+            DictIncluding({"name": "my_param", "class": "builtins.str", "value": "example"})
         ]
 
 


### PR DESCRIPTION
- [x] Replace `isinstance(val, str)` with `issubclass(type(val), str)` to avoid `__class__` lookups on proxy/lazy objects
- [x] Update the `display_string` docstring/comment to reflect that `str` types return raw values (not `repr()`)
- [x] Verify all tests pass