### PR TITLE
fix: don't create log file by default, never log full environment

### DIFF
--- a/_appmap/configuration.py
+++ b/_appmap/configuration.py
@@ -508,5 +508,13 @@ if _startup_messages_shown is None:
     logger.info("file: %s", c._file if c.file_present else "[no appmap.yml]")
     logger.info("config: %r", c)
     logger.debug("package_functions: %s", c.package_functions)
-    logger.info("env: %r", os.environ)
+    # Only log AppMap's own settings, never the full environment: arbitrary
+    # environment variables (API keys, credentials, tokens, etc.) must never
+    # end up in application logs.
+    appmap_env = {
+        k: v
+        for k, v in os.environ.items()
+        if k in ("APPMAP", "_APPMAP") or k.startswith(("APPMAP_", "_APPMAP_"))
+    }
+    logger.info("env: %r", appmap_env)
     os.environ["_APPMAP_MESSAGES_SHOWN"] = "true"

--- a/_appmap/env.py
+++ b/_appmap/env.py
@@ -168,7 +168,10 @@ class Env(metaclass=SingletonMeta):
         trace_logger.install()
 
         log_level = self.get("APPMAP_LOG_LEVEL", "warn").upper()
-        disable_log = os.environ.get("APPMAP_DISABLE_LOG_FILE", "false").upper() != "FALSE"
+        # No log file unless the user opts in: it can contain data (e.g.
+        # rendered parameter values) that shouldn't be written to disk or
+        # committed to source control by default.
+        disable_log = os.environ.get("APPMAP_DISABLE_LOG_FILE", "true").upper() != "FALSE"
         log_config = self.get("APPMAP_LOG_CONFIG")
         config_dict = {
             "version": 1,

--- a/_appmap/test/test_runner.py
+++ b/_appmap/test/test_runner.py
@@ -37,6 +37,20 @@ def test_runner_multi_recording_type(script_runner, flag, expected):
     assert len(re.findall("(?m)^APPMAP_RECORD_PYTEST=true$", result.stdout)) == expected
 
 
+@pytest.mark.parametrize(
+    "flags,expected",
+    [
+        ([], "true"),
+        (["--no-enable-log"], "true"),
+        (["--enable-log"], "false"),
+    ],
+)
+def test_runner_log_file_disabled_by_default(script_runner, flags, expected):
+    result = script_runner.run(["appmap-python", *flags, "--record", "process"])
+    assert result.returncode == 0
+    assert re.search(f"(?m)^APPMAP_DISABLE_LOG_FILE={expected}$", result.stdout) is not None
+
+
 @pytest.mark.script_launch_mode("subprocess")
 class TestEnv:
     def test_appmap_present(self, script_runner):

--- a/_appmap/test/test_runner.py
+++ b/_appmap/test/test_runner.py
@@ -1,3 +1,4 @@
+import os
 import re
 
 import pytest
@@ -64,3 +65,19 @@ class TestEnv:
         )
         assert result.returncode == 0
         assert re.match(r"true", result.stdout) is not None
+
+    def test_internal_state_not_leaked_to_child(self, script_runner):
+        # appmap-python is itself instrumented at interpreter startup (via
+        # appmap.pth), which can set internal, process-scoped _APPMAP*
+        # markers using whatever it inherited, before this script has
+        # computed the environment the child command should actually run
+        # with. Simulate that by pre-setting one such marker (the
+        # once-per-process "startup messages already shown" guard) and
+        # confirm it doesn't leak into the child's environment, which would
+        # otherwise silently suppress the child's own startup logging.
+        env = {**os.environ, "_APPMAP_MESSAGES_SHOWN": "true"}
+        result = script_runner.run(
+            ["appmap-python", "printenv", "_APPMAP_MESSAGES_SHOWN"], env=env
+        )
+        assert result.returncode != 0
+        assert result.stdout == ""

--- a/appmap/command/runner.py
+++ b/appmap/command/runner.py
@@ -122,7 +122,7 @@ def run():
         envvars[f"APPMAP_RECORD_{disabled.upper()}"] = "false"
 
     envvars["APPMAP_DISABLE_LOG_FILE"] = (
-        "true" if parsed_args.get("no_enable_log", set()) else "false"
+        "false" if parsed_args.get("enable_log", False) else "true"
     )
 
     if len(cmd) == 0:

--- a/appmap/command/runner.py
+++ b/appmap/command/runner.py
@@ -130,7 +130,17 @@ def run():
             print(f"{k}={v}")
         sys.exit(0)
 
-    os.execvpe(cmd[0], cmd, {**os.environ, **envvars})
+    # appmap-python is itself instrumented on interpreter startup (via
+    # appmap.pth), before this point, using whatever environment it inherited
+    # rather than the envvars computed above. That incidental self-init can
+    # set internal, process-scoped state under _APPMAP*-prefixed names (e.g.
+    # the once-per-process "startup messages already shown" guard); left in
+    # place, it would carry over into the child's environment and suppress
+    # or corrupt the child's own startup behavior. Drop all of it and let
+    # envvars below re-set whatever the child actually needs.
+    child_env = {k: v for k, v in os.environ.items() if not k.startswith("_APPMAP")}
+    child_env.update(envvars)
+    os.execvpe(cmd[0], cmd, child_env)
 
 
 if __name__ == "__main__":

--- a/ci/tests/smoketest.sh
+++ b/ci/tests/smoketest.sh
@@ -26,7 +26,9 @@ test_log_file_not_writable()
 import appmap
 EOF
 
-  python test_log_file_not_writable.py
+  # Log file creation is opt-in, so force it on to exercise the fallback
+  # when the log file can't be created (e.g. read-only mount).
+  APPMAP_DISABLE_LOG_FILE=false python test_log_file_not_writable.py
 
   if [[ $? -eq 0 ]]; then
     echo 'Script executed successfully'


### PR DESCRIPTION
## Summary

A user hit a real security incident: the agent silently wrote `appmap.log` (including a full dump of `os.environ`, i.e. any secrets in the process environment) to disk, and the file got accidentally committed to git.

Two bugs combined to cause this:
- `appmap-python` (the wrapper script) had a bug where `APPMAP_DISABLE_LOG_FILE` was **always** set to `"false"`, regardless of the `--enable-log`/`--no-enable-log` flag — it checked a namespace key (`no_enable_log`) that never actually exists, so the log file was always created even though `--help` documents the flag's default as `False`.
- `_appmap/env.py` independently defaulted to creating the log file (`APPMAP_DISABLE_LOG_FILE` defaulting to `"false"`) when the wrapper wasn't used at all.
- `_appmap/configuration.py` logged the entire `os.environ` at startup (`logger.info("env: %r", os.environ)`), which is how arbitrary secrets ended up in the file once one existed.

While fixing this, also found and fixed a separate wrapper-only bug: `appmap-python` is itself instrumented at interpreter startup (via `appmap.pth` — AppMap instruments any Python process by default), before `runner.py`'s own code computes the environment the target command should run with. That incidental self-init can set internal, process-scoped `_APPMAP*` state using whatever it inherited — notably the once-per-process guard around the startup config-dump log lines — which then leaked into the exec'd child via `os.execvpe`'s environment inheritance, silently suppressing that child's own startup logging even when everything else was configured correctly (e.g. `appmap-python --enable-log flask run`).

## Changes

- `appmap/command/runner.py`: fixed `--enable-log`/`--no-enable-log` to actually control `APPMAP_DISABLE_LOG_FILE`; strips all `_APPMAP*`-prefixed env vars before exec'ing the child so none of the wrapper's own incidental self-init state can leak through.
- `_appmap/env.py`: `APPMAP_DISABLE_LOG_FILE` now defaults to `true` — no log file unless a user explicitly opts in.
- `_appmap/configuration.py`: only the exact `APPMAP`/`_APPMAP` settings and `APPMAP_*`/`_APPMAP_*`-prefixed settings are logged at startup, never the full environment or unrelated variables that merely share the prefix (e.g. `APPMAPX_*`).
- `ci/tests/smoketest.sh`: updated the read-only-log-file smoketest to explicitly opt in to log file creation, since it's no longer on by default.
- `_appmap/test/test_runner.py`: coverage for the corrected `--enable-log` behavior and for the `_APPMAP*` leak fix.

## Test plan
- [x] `appmap-python pytest _appmap/test/test_runner.py _appmap/test/test_env.py _appmap/test/test_configuration.py` — all pass, including new tests
- [x] Manually verified: running via `appmap-python python script.py` with no flags creates no `appmap.log`
- [x] Manually verified: `APPMAP_DISABLE_LOG_FILE=false` opts back in, and a planted secret env var no longer appears in the resulting log (only `APPMAP_*` settings do)
- [x] Manually verified with a real Flask app: `appmap-python --enable-log flask run` now correctly logs the startup config dump, which it silently dropped before the `_APPMAP*`-leak fix
